### PR TITLE
Add TCP and HTTP check parameters to fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,25 @@ primary_region = 'ams'
   min_machines_running = 0
   processes = ['app']
 
+[[services.tcp_checks]]
+	grace_period = "1s"
+	interval = "15s"
+	restart_limit = 0
+	timeout = "2s"
+
+[[services.http_checks]]
+	interval = 10000
+	grace_period = "5s"
+	method = "HEAD"
+	path = "/"
+	protocol = "http"
+	timeout = 2000
+	tls_skip_verify = false
+	[services.http_checks.headers]
+
+
+
+
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'


### PR DESCRIPTION
In this commit, more configurations have been added to the 'fly.toml' file. Specifically, TCP and HTTP checks have been added with attributes such as grace period, interval, restart limit, and timeout defined. This is to ensure more thorough service checks are implemented.