### PR TITLE
Add TLS and HTTP handlers to services ports

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,10 @@ primary_region = 'ams'
   min_machines_running = 0
   processes = ['app']
 
+[[services.ports]]
+	handlers = ["tls", "http"]
+	port = 443
+
 [[services.tcp_checks]]
 	grace_period = "1s"
 	interval = "15s"
@@ -31,9 +35,6 @@ primary_region = 'ams'
 	timeout = 2000
 	tls_skip_verify = false
 	[services.http_checks.headers]
-
-
-
 
 [[vm]]
   memory = '1gb'


### PR DESCRIPTION
The commit reflects the changes in the fly.toml configuration file where a new section for TLS and HTTP handlers was added under services ports. This update configures the application to listen on port 443, enhancing its communication security.