### PR TITLE
Update HTTP check method in fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -29,7 +29,7 @@ primary_region = 'ams'
 [[services.http_checks]]
 	interval = 10000
 	grace_period = "5s"
-	method = "HEAD"
+	method = "get"
 	path = "/"
 	protocol = "http"
 	timeout = 2000


### PR DESCRIPTION
Changed the HTTP check method from "HEAD" to "get" in the services configuration within fly.toml. This adjustment ensures proper operation by following standard HTTP request types.