### PR TITLE
Add healthcheck route and enhance services checks

### DIFF
--- a/apps/web/app/routes/resources.healthcheck.tsx
+++ b/apps/web/app/routes/resources.healthcheck.tsx
@@ -1,0 +1,8 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+
+export async function loader(_: LoaderFunctionArgs): Promise<Response> {
+	return new Response('OK', {
+		status: 200,
+		statusText: 'OK',
+	})
+}

--- a/fly.toml
+++ b/fly.toml
@@ -21,18 +21,28 @@ primary_region = 'ams'
 	port = 443
 
 [[services.tcp_checks]]
-	grace_period = "1s"
+	grace_period = "10s"
 	interval = "15s"
 	restart_limit = 0
 	timeout = "2s"
 
 [[services.http_checks]]
-	interval = 10000
+	interval = 10_000
 	grace_period = "5s"
 	method = "get"
 	path = "/"
 	protocol = "http"
-	timeout = 2000
+	timeout = 2_000
+	tls_skip_verify = false
+	[services.http_checks.headers]
+
+[[services.http_checks]]
+	interval = 10_000
+	grace_period = "5s"
+	method = "get"
+	path = "/resources/healthcheck"
+	protocol = "http"
+	timeout = 2_000
 	tls_skip_verify = false
 	[services.http_checks.headers]
 


### PR DESCRIPTION
A new healthcheck route has been created in the resources directory of the web application. This was then incorporated into the services checks in fly.toml for http. Additionally, the grace period for tcp checks has been modified to be more liberal, allowing for a 10 second period before failing.