### PR TITLE
Update deployment commands in Github workflow

### DIFF
--- a/.github/workflows/deply.yml
+++ b/.github/workflows/deply.yml
@@ -17,5 +17,4 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        with:
-          args: "deploy --remote-only"
+        run: flyctl deploy --remote-only


### PR DESCRIPTION
This commit updates the deployment commands used in the Github Actions workflow. The argument style of running the deployment command has been changed to a direct command execution. This makes the workflow file easier to read and understand.