### PR TITLE
Add schema to renovate configuration file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,4 @@
 {
-	"extends": ["config:recommended"]
+	$schema: "https://docs.renovatebot.com/renovate-schema.json",
+	extends: ["config:recommended"],
 }


### PR DESCRIPTION
A '$schema' field has been added to the renovate.json5 configuration file. This provides a link to the Renovate schema documentation, improving maintainability and understanding of the configuration.