### PR TITLE
Update Node base image and remove package update

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:21-bookworm-slim
+FROM node:21-alpine3.19
 LABEL authors="suddenlyGiovanni"
 
 # set for base and all layer that inherit from it
@@ -7,7 +7,6 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV NODE_ENV=production
 
-RUN apt-get update && apt-get install -y
 RUN corepack enable
 
 USER node


### PR DESCRIPTION
The Node base image in the Dockerfile was updated to 'node:21-alpine3.19' for improved performance and efficiency. Additionally, the unnecessary package update command was removed, simplifying the build process and reducing potential vulnerabilities.