### PR TITLE
Update prettier-plugin-tailwindcss version and rollup version

### DIFF
--- a/packages/config-prettier/package.json
+++ b/packages/config-prettier/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-	"main": "index.js",
+  "main": "index.js",
   "scripts": {
-		"clean": "scripty"
+    "clean": "scripty"
   },
   "peerDependenciesMeta": {
     "prettier": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@suddenly-giovanni/config-typescript": "workspace:*",
-    "prettier-plugin-tailwindcss": "0.5.11"
+    "prettier-plugin-tailwindcss": "0.5.12"
   },
   "config": {
     "scripty": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../config-typescript
       prettier-plugin-tailwindcss:
-        specifier: 0.5.11
-        version: 0.5.11(prettier@3.2.5)
+        specifier: 0.5.12
+        version: 0.5.12(prettier@3.2.5)
 
   packages/config-tailwind:
     devDependencies:
@@ -12589,8 +12589,8 @@ packages:
       synckit: 0.9.0
     dev: true
 
-  /prettier-plugin-tailwindcss@0.5.11(prettier@3.2.5):
-    resolution: {integrity: sha512-AvI/DNyMctyyxGOjyePgi/gqj5hJYClZ1avtQvLlqMT3uDZkRbi4HhGUpok3DRzv9z7Lti85Kdj3s3/1CeNI0w==}
+  /prettier-plugin-tailwindcss@0.5.12(prettier@3.2.5):
+    resolution: {integrity: sha512-o74kiDBVE73oHW+pdkFSluHBL3cYEvru5YgEqNkBMFF7Cjv+w1vI565lTlfoJT4VLWDe0FMtZ7FkE/7a4pMXSQ==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -12605,6 +12605,7 @@ packages:
       prettier-plugin-marko: '*'
       prettier-plugin-organize-attributes: '*'
       prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
       prettier-plugin-style-order: '*'
       prettier-plugin-svelte: '*'
       prettier-plugin-twig-melody: '*'
@@ -12630,6 +12631,8 @@ packages:
       prettier-plugin-organize-attributes:
         optional: true
       prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
         optional: true
       prettier-plugin-style-order:
         optional: true


### PR DESCRIPTION
The version of prettier-plugin-tailwindcss has been updated to 0.5.12 in package.json and the lock file. Also, the rollup version has been updated to 4.12.1 in pnpm-lock.yaml. These updates include various builds for different architectures and operating systems.