### PR TITLE
Update import paths using alias '@' for ui package

### DIFF
--- a/packages/ui/src/components/accordion/accordion.stories.tsx
+++ b/packages/ui/src/components/accordion/accordion.stories.tsx
@@ -5,14 +5,14 @@
 
 import type { Meta } from '@storybook/react'
 import { type ReactElement, useEffect, useRef, useState } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 import {
 	Accordion,
 	AccordionContent,
 	AccordionHeader,
 	AccordionItem,
 	AccordionTrigger,
-} from '~/ui/accordion.tsx'
+} from '@/ui/accordion.tsx'
 
 const meta = {
 	component: Accordion,

--- a/packages/ui/src/components/button/button.stories.tsx
+++ b/packages/ui/src/components/button/button.stories.tsx
@@ -1,7 +1,7 @@
 import { ChevronRightIcon, EnvelopeOpenIcon, ReloadIcon } from '@radix-ui/react-icons'
 import type { Meta, StoryObj } from '@storybook/react'
-import { T } from '~/components/typography/typography.tsx'
-import { Button } from '~/ui/button.tsx'
+import { T } from '@/components/typography/typography.tsx'
+import { Button } from '@/ui/button.tsx'
 
 const meta = {
 	component: Button,

--- a/packages/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/packages/ui/src/components/collapsible/collapsible.stories.tsx
@@ -1,9 +1,9 @@
 import { CaretSortIcon } from '@radix-ui/react-icons'
 import type { Meta } from '@storybook/react'
 import { type ReactElement, useState } from 'react'
-import { clsx } from '~/lib/utils.ts'
-import { Button } from '~/ui/button.tsx'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '~/ui/collapsible.tsx'
+import { clsx } from '@/lib/utils.ts'
+import { Button } from '@/ui/button.tsx'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ui/collapsible.tsx'
 
 const rootClass = clsx('sans max-w-[20em]')
 

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,7 +1,7 @@
 import type { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu'
 import type { Meta, StoryFn } from '@storybook/react'
 import { useCallback, useState } from 'react'
-import { Button } from '~/ui/button.tsx'
+import { Button } from '@/ui/button.tsx'
 import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
@@ -18,7 +18,7 @@ import {
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
-} from '~/ui/dropdown-menu'
+} from '@/ui/dropdown-menu'
 
 const meta: Meta = {
 	component: DropdownMenu,

--- a/packages/ui/src/components/layout/body.stories.tsx
+++ b/packages/ui/src/components/layout/body.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Placeholder } from '~/components/placeholder/placeholder.tsx'
+import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/footer.stories.tsx
+++ b/packages/ui/src/components/layout/footer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Placeholder } from '~/components/placeholder/placeholder.tsx'
+import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/header.stories.tsx
+++ b/packages/ui/src/components/layout/header.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Placeholder } from '~/components/placeholder/placeholder.tsx'
+import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/layout.tsx
+++ b/packages/ui/src/components/layout/layout.tsx
@@ -2,8 +2,8 @@ import { type ElementType, type JSX, forwardRef } from 'react'
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,
-} from '~/lib/polymorphic-component-prop.tsx'
-import { clsx } from '~/lib/utils.ts'
+} from '@/lib/polymorphic-component-prop.tsx'
+import { clsx } from '@/lib/utils.ts'
 
 const bodyName = 'Body'
 const Body = forwardRef(

--- a/packages/ui/src/components/layout/main.stories.tsx
+++ b/packages/ui/src/components/layout/main.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Placeholder } from '~/components/placeholder/placeholder.tsx'
+import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/mode-toggle/mode-toggle.tsx
+++ b/packages/ui/src/components/mode-toggle/mode-toggle.tsx
@@ -4,15 +4,15 @@
 	*/
 import { type ReactNode, memo, useMemo } from 'react'
 import { Theme } from 'remix-themes'
-import { Icons } from '~/components/icons/icons.tsx'
-import { clsx } from '~/lib/utils.ts'
-import { Button } from '~/ui/button.tsx'
+import { Icons } from '@/components/icons/icons.tsx'
+import { clsx } from '@/lib/utils.ts'
+import { Button } from '@/ui/button.tsx'
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
-} from '~/ui/dropdown-menu.tsx'
+} from '@/ui/dropdown-menu.tsx'
 
 interface ModeToggleProps {
 	readonly setTheme: (theme: Theme) => void

--- a/packages/ui/src/components/navigation-menu-toggle/hamburger-icon.tsx
+++ b/packages/ui/src/components/navigation-menu-toggle/hamburger-icon.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 const baseClasses = clsx(
 	'absolute',

--- a/packages/ui/src/components/navigation-menu-toggle/navigation-menu-toggle.tsx
+++ b/packages/ui/src/components/navigation-menu-toggle/navigation-menu-toggle.tsx
@@ -1,7 +1,7 @@
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon'
 import type { ReactElement } from 'react'
 import { ToggleButton, type ToggleButtonProps, composeRenderProps } from 'react-aria-components'
-import { clsx, tv } from '~/lib/utils.ts'
+import { clsx, tv } from '@/lib/utils.ts'
 import { HamburgerIcon } from './hamburger-icon.tsx'
 
 const styles = tv({

--- a/packages/ui/src/components/navigation-menu/navigation-menu.stories.tsx
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.stories.tsx
@@ -2,8 +2,8 @@ import { Link } from '@remix-run/react'
 import type { Meta } from '@storybook/react'
 import type { ComponentPropsWithoutRef, ElementRef, ReactElement } from 'react'
 import { forwardRef } from 'react'
-import { Icons } from '~/components/icons/icons.tsx'
-import { clsx } from '~/lib/utils.ts'
+import { Icons } from '@/components/icons/icons.tsx'
+import { clsx } from '@/lib/utils.ts'
 import {
 	NavigationMenu,
 	NavigationMenuContent,
@@ -12,7 +12,7 @@ import {
 	NavigationMenuList,
 	NavigationMenuTrigger,
 	navigationMenuTriggerStyle,
-} from '~/ui/navigation-menu.tsx'
+} from '@/ui/navigation-menu.tsx'
 
 const meta: Meta = {
 	component: NavigationMenu,

--- a/packages/ui/src/components/placeholder/placeholder.tsx
+++ b/packages/ui/src/components/placeholder/placeholder.tsx
@@ -1,5 +1,5 @@
 import { type JSX, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 const name = 'Placeholder'
 export const Placeholder = forwardRef<HTMLDivElement, JSX.IntrinsicElements['div']>(

--- a/packages/ui/src/components/skeleton/skeleton.stories.tsx
+++ b/packages/ui/src/components/skeleton/skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react'
-import { Skeleton } from '~/ui/skeleton'
+import { Skeleton } from '@/ui/skeleton'
 
 const meta = {
 	component: Skeleton,

--- a/packages/ui/src/components/social/social-icon.tsx
+++ b/packages/ui/src/components/social/social-icon.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- Reason map api force to re-check  */
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { Icons } from '~/components/icons/icons.tsx'
+import { Icons } from '@/components/icons/icons.tsx'
 
 export const IconMap = new Map([
 	['twitter', Icons.twitter],

--- a/packages/ui/src/components/social/social.tsx
+++ b/packages/ui/src/components/social/social.tsx
@@ -1,6 +1,6 @@
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon'
 import type { JSX, ReactElement } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 import { SocialIcon } from './social-icon.tsx'
 
 function SocialLink({ className, children, ...props }: JSX.IntrinsicElements['a']): ReactElement {

--- a/packages/ui/src/components/suddenly-giovanni/suddenly-giovanni.tsx
+++ b/packages/ui/src/components/suddenly-giovanni/suddenly-giovanni.tsx
@@ -1,9 +1,9 @@
 import type { LinkProps } from '@remix-run/react'
 import { Link } from '@remix-run/react'
 import type { JSX } from 'react'
-import { clsx } from '~/lib/utils.ts'
-import { Avatar, AvatarFallback, AvatarImage } from '~/ui/avatar.tsx'
-import { Skeleton } from '~/ui/skeleton.tsx'
+import { clsx } from '@/lib/utils.ts'
+import { Avatar, AvatarFallback, AvatarImage } from '@/ui/avatar.tsx'
+import { Skeleton } from '@/ui/skeleton.tsx'
 
 export function SuddenlyGiovanni({
 	className,

--- a/packages/ui/src/components/typography/a.tsx
+++ b/packages/ui/src/components/typography/a.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const A = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/blockquote.tsx
+++ b/packages/ui/src/components/typography/blockquote.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Blockquote = forwardRef<HTMLQuoteElement, ComponentPropsWithoutRef<'blockquote'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/code.tsx
+++ b/packages/ui/src/components/typography/code.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Code = forwardRef<HTMLElement, ComponentPropsWithoutRef<'code'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h1.tsx
+++ b/packages/ui/src/components/typography/h1.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const H1 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h1'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h2.tsx
+++ b/packages/ui/src/components/typography/h2.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const H2 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h2'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h3.tsx
+++ b/packages/ui/src/components/typography/h3.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const H3 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h3'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h4.tsx
+++ b/packages/ui/src/components/typography/h4.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const H4 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h4'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/large.tsx
+++ b/packages/ui/src/components/typography/large.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Large = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/lead.tsx
+++ b/packages/ui/src/components/typography/lead.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Lead = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/muted.tsx
+++ b/packages/ui/src/components/typography/muted.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Muted = forwardRef<HTMLParagraphElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/p.tsx
+++ b/packages/ui/src/components/typography/p.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const P = forwardRef<HTMLParagraphElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/prose.stories.tsx
+++ b/packages/ui/src/components/typography/prose.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unescaped-entities -- Reason: storybook story */
 import type { Meta } from '@storybook/react'
 import type { ReactElement } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 const meta = {
 	title: 'components/typography/Prose',

--- a/packages/ui/src/components/typography/small.tsx
+++ b/packages/ui/src/components/typography/small.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Small = forwardRef<HTMLElement, ComponentPropsWithoutRef<'small'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/table.tsx
+++ b/packages/ui/src/components/typography/table.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Tr = forwardRef<HTMLTableRowElement, ComponentPropsWithoutRef<'tr'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/ul.tsx
+++ b/packages/ui/src/components/typography/ul.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Ul = forwardRef<HTMLUListElement, ComponentPropsWithoutRef<'ul'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/ui/accordion.tsx
+++ b/packages/ui/src/ui/accordion.tsx
@@ -1,7 +1,7 @@
 import { Content, Header, Item, Root, Trigger } from '@radix-ui/react-accordion'
 import { ChevronDownIcon } from '@radix-ui/react-icons'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils'
+import { clsx } from '@/lib/utils'
 
 const Accordion = Root
 Accordion.displayName = Root.displayName

--- a/packages/ui/src/ui/avatar.tsx
+++ b/packages/ui/src/ui/avatar.tsx
@@ -1,6 +1,6 @@
 import { Fallback, Image, Root } from '@radix-ui/react-avatar'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils'
+import { clsx } from '@/lib/utils'
 
 const Avatar = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, ...props }, ref) => (

--- a/packages/ui/src/ui/button.tsx
+++ b/packages/ui/src/ui/button.tsx
@@ -1,6 +1,6 @@
 import { Slot } from '@radix-ui/react-slot'
 import { type ButtonHTMLAttributes, forwardRef } from 'react'
-import { type VariantProps, clsx, cva } from '~/lib/utils.ts'
+import { type VariantProps, clsx, cva } from '@/lib/utils.ts'
 
 const buttonVariants = cva(
 	clsx(

--- a/packages/ui/src/ui/dropdown-menu.tsx
+++ b/packages/ui/src/ui/dropdown-menu.tsx
@@ -23,7 +23,7 @@ import {
 	type ReactElement,
 	forwardRef,
 } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 const DropdownMenu = Root
 const DropdownMenuTrigger = Trigger

--- a/packages/ui/src/ui/navigation-menu.tsx
+++ b/packages/ui/src/ui/navigation-menu.tsx
@@ -11,7 +11,7 @@ import {
 	Viewport,
 } from '@radix-ui/react-navigation-menu'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
-import { clsx, cva } from '~/lib/utils.ts'
+import { clsx, cva } from '@/lib/utils.ts'
 
 const NavigationMenu = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/ui/separator.tsx
+++ b/packages/ui/src/ui/separator.tsx
@@ -1,6 +1,6 @@
 import { Root } from '@radix-ui/react-separator'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Separator = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (

--- a/packages/ui/src/ui/skeleton.tsx
+++ b/packages/ui/src/ui/skeleton.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
-import { clsx } from '~/lib/utils.ts'
+import { clsx } from '@/lib/utils.ts'
 
 export const Skeleton = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
 	({ className, ...props }, ref) => (

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,7 +4,7 @@
 	"compilerOptions": {
 		"noEmit": true,
 		"paths": {
-			"~/*": ["./src/*"]
+			"@/*": ["./src/*"]
 		},
 		"types": ["@total-typescript/ts-reset", "vite/client", "react", "react-dom"],
 		"useDefineForClassFields": true


### PR DESCRIPTION
All relative import paths within the UI package have been updated to use
 the '@' alias instead of the previous '~' to align with the new alias
 configuration. This change simplifies the import statements and
 standardizes the import path across the codebase.