### PR TITLE
CI un-pin checkout action version

### DIFF
--- a/.github/workflows/deply.yml
+++ b/.github/workflows/deply.yml
@@ -11,7 +11,7 @@ jobs:
     concurrency: deploy-group # this ensures only one action run at a time
     steps:
       - name: ⬇️Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: 📠 Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
The commit upgrades the checkout action version in the deployment workflow from a specific commit hash to the general version 4. This change facilitates compatibility and maintainability by using a stable released version instead of a specific commit.