### PR TITLE
Update package manager and relax lockfile enforcement

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -30,7 +30,7 @@ COPY .gitignore .gitignore
 
 COPY --from=builder /home/node/builder/out/json/ .
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod=false
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile=false --prod=false
 
 # Build the project
 COPY --from=builder /home/node/builder/out/full/ .

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
 	"engines": {
 		"node": ">=21"
 	},
+	"packageManager": "pnpm@8.15.5",
 	"config": {
 		"scripty": {
 			"path": "../../scripts"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "turbo": "1.13.0",
     "typescript": "5.4.3"
   },
-  "packageManager": "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589",
+  "packageManager": "pnpm@8.15.5",
   "engines": {
     "node": ">=21"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,6 +77,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"packageManager": "pnpm@8.15.5",
 	"config": {
 		"scripty": {
 			"path": "../../scripts"


### PR DESCRIPTION
This commit updates the package manager to pnpm@8.15.5 in the web and ui
 modules, streamlining our workflow. It also modifies the Dockerfile to
 turn off --frozen-lockfile option. This change will allow for updates
 to dependencies even when a lockfile already exists. The decision for
 this alteration is to provide more flexibility during the installation
 of packages.