### PR TITLE
 Removal of Path Alias in UI Library tsconfig

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,6 +3,9 @@
 	"extends": "@suddenly-giovanni/config-typescript/remix.json",
 	"compilerOptions": {
 		"baseUrl": ".",
+		"paths": {
+			"~/*": ["./app/*"]
+		},
 		"lib": ["DOM", "DOM.Iterable", "ES2022"],
 		"noEmit": true,
 		"skipLibCheck": true,

--- a/packages/ui/src/components/accordion/accordion.stories.tsx
+++ b/packages/ui/src/components/accordion/accordion.stories.tsx
@@ -44,14 +44,14 @@ const itemClass = clsx(
 
 const headerClass = clsx('m-0', 'data-[orientation=horizontal]:h-full')
 
-const RECOMMENDED_CSS__ACCORDION__TRIGGER = clsx(
+const recommendedCssAccordionTrigger = clsx(
 	'align-inherit',
 	'data-[orientation=horizontal]:h-full',
 	'data-[orientation=vertical]:w-full',
 )
 
 const triggerClass = clsx(
-	RECOMMENDED_CSS__ACCORDION__TRIGGER,
+	recommendedCssAccordionTrigger,
 	['box-border border-0 bg-black p-2.5 text-lg text-white'],
 	'focus:text-red-500 focus:shadow-inner focus:outline-none',
 	'data-[disabled]:text-gray-300',

--- a/packages/ui/src/components/accordion/accordion.stories.tsx
+++ b/packages/ui/src/components/accordion/accordion.stories.tsx
@@ -2,17 +2,17 @@
 	eslint-disable react/no-array-index-key,
 		react/no-unescaped-entities -- Reason: This rule is disabled because...
 */
+import type { Meta } from '@storybook/react'
+import { type ReactElement, useEffect, useRef, useState } from 'react'
 
-import { clsx } from '@/lib/utils.ts'
+import { clsx } from '../../lib/utils.ts'
 import {
 	Accordion,
 	AccordionContent,
 	AccordionHeader,
 	AccordionItem,
 	AccordionTrigger,
-} from '@/ui/accordion.tsx'
-import type { Meta } from '@storybook/react'
-import { type ReactElement, useEffect, useRef, useState } from 'react'
+} from '../../ui/accordion.tsx'
 
 const meta = {
 	component: Accordion,
@@ -92,7 +92,7 @@ const contentAttrClass = clsx('block', styles)
 
 export function _Accordion(): ReactElement {
 	return (
-		<Accordion className="w-full" collapsible type="single">
+		<Accordion className="w-full" collapsible={true} type="single">
 			<AccordionItem value="item-1">
 				<AccordionTrigger>Is it accessible?</AccordionTrigger>
 				<AccordionContent>Yes. It adheres to the WAI-ARIA design pattern.</AccordionContent>
@@ -137,7 +137,7 @@ export function SingleUncontrolled(): ReactElement {
 					porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 				</AccordionContent>
 			</AccordionItem>
-			<AccordionItem className={itemClass} disabled value="three">
+			<AccordionItem className={itemClass} disabled={true} value="three">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 				</AccordionHeader>
@@ -187,7 +187,7 @@ export function SingleControlled(): ReactElement {
 					porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 				</AccordionContent>
 			</AccordionItem>
-			<AccordionItem className={itemClass} disabled value="three">
+			<AccordionItem className={itemClass} disabled={true} value="three">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 				</AccordionHeader>
@@ -212,7 +212,7 @@ export function SingleControlled(): ReactElement {
 
 export function SingleCollapsible(): ReactElement {
 	return (
-		<Accordion className={rootClass} collapsible defaultValue="one" type="single">
+		<Accordion className={rootClass} collapsible={true} defaultValue="one" type="single">
 			<AccordionItem className={itemClass} value="one">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>One</AccordionTrigger>
@@ -232,7 +232,7 @@ export function SingleCollapsible(): ReactElement {
 					porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 				</AccordionContent>
 			</AccordionItem>
-			<AccordionItem className={itemClass} disabled value="three">
+			<AccordionItem className={itemClass} disabled={true} value="three">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 				</AccordionHeader>
@@ -277,7 +277,7 @@ export function MultipleUncontrolled(): ReactElement {
 					porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 				</AccordionContent>
 			</AccordionItem>
-			<AccordionItem className={itemClass} disabled value="three">
+			<AccordionItem className={itemClass} disabled={true} value="three">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 				</AccordionHeader>
@@ -330,7 +330,7 @@ export function MultipleControlled(): ReactElement {
 					porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 				</AccordionContent>
 			</AccordionItem>
-			<AccordionItem className={itemClass} disabled value="three">
+			<AccordionItem className={itemClass} disabled={true} value="three">
 				<AccordionHeader className={headerClass}>
 					<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 				</AccordionHeader>
@@ -542,7 +542,7 @@ export function OutsideViewport(): ReactElement {
 						porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 					</AccordionContent>
 				</AccordionItem>
-				<AccordionItem className={itemClass} disabled value="three">
+				<AccordionItem className={itemClass} disabled={true} value="three">
 					<AccordionHeader className={headerClass}>
 						<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 					</AccordionHeader>
@@ -592,7 +592,7 @@ export function Horizontal(): ReactElement {
 						porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
 					</AccordionContent>
 				</AccordionItem>
-				<AccordionItem className={itemClass} disabled value="three">
+				<AccordionItem className={itemClass} disabled={true} value="three">
 					<AccordionHeader className={headerClass}>
 						<AccordionTrigger className={triggerClass}>Three (disabled)</AccordionTrigger>
 					</AccordionHeader>
@@ -719,7 +719,7 @@ export function Chromatic(): ReactElement {
 			</Accordion>
 
 			<h1>Disabled (whole)</h1>
-			<Accordion className={rootClass} disabled type="single">
+			<Accordion className={rootClass} disabled={true} type="single">
 				{items.map(item => (
 					<AccordionItem className={itemClass} key={item} value={item}>
 						<AccordionHeader className={headerClass}>
@@ -774,7 +774,7 @@ export function Chromatic(): ReactElement {
 						<AccordionHeader className={headerClass}>
 							<AccordionTrigger className={triggerClass}>{item}</AccordionTrigger>
 						</AccordionHeader>
-						<AccordionContent className={contentClass} forceMount>
+						<AccordionContent className={contentClass} forceMount={true}>
 							{item}: Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate
 							viverra integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam
 							suscipit habitant sed.
@@ -785,7 +785,7 @@ export function Chromatic(): ReactElement {
 
 			<h1>State attributes</h1>
 			<h2>Accordion disabled</h2>
-			<Accordion className={rootAttrClass} defaultValue="Two" disabled type="single">
+			<Accordion className={rootAttrClass} defaultValue="Two" disabled={true} type="single">
 				{items.map(item => (
 					<AccordionItem className={itemAttrClass} key={item} value={item}>
 						<AccordionHeader className={headerAttrClass}>
@@ -822,7 +822,7 @@ export function Chromatic(): ReactElement {
 			</Accordion>
 
 			<h2>Accordion disabled with item override</h2>
-			<Accordion className={rootAttrClass} defaultValue="Two" disabled type="single">
+			<Accordion className={rootAttrClass} defaultValue="Two" disabled={true} type="single">
 				{items.map(item => (
 					<AccordionItem
 						className={itemAttrClass}

--- a/packages/ui/src/components/button/button.stories.tsx
+++ b/packages/ui/src/components/button/button.stories.tsx
@@ -1,7 +1,8 @@
-import { T } from '@/components/typography/typography.tsx'
-import { Button } from '@/ui/button.tsx'
 import { ChevronRightIcon, EnvelopeOpenIcon, ReloadIcon } from '@radix-ui/react-icons'
 import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../../ui/button.tsx'
+import { T } from '../typography/typography'
 
 const meta = {
 	component: Button,
@@ -65,7 +66,7 @@ export const WithIcon: Story = {
 
 export const Loading: Story = {
 	render: args => (
-		<Button {...args} disabled>
+		<Button {...args} disabled={true}>
 			<ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
 			Please wait
 		</Button>
@@ -74,7 +75,7 @@ export const Loading: Story = {
 
 export const AsChild: Story = {
 	render: args => (
-		<Button {...args} asChild>
+		<Button {...args} asChild={true}>
 			<T.a href="#1">Login</T.a>
 		</Button>
 	),

--- a/packages/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/packages/ui/src/components/collapsible/collapsible.stories.tsx
@@ -1,9 +1,10 @@
-import { clsx } from '@/lib/utils.ts'
-import { Button } from '@/ui/button.tsx'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ui/collapsible.tsx'
 import { CaretSortIcon } from '@radix-ui/react-icons'
 import type { Meta } from '@storybook/react'
 import { type ReactElement, useState } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
+import { Button } from '../../ui/button.tsx'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../ui/collapsible.tsx'
 
 const rootClass = clsx('sans max-w-[20em]')
 
@@ -45,7 +46,7 @@ export function Default(): ReactElement {
 		<Collapsible className="w-[350px] space-y-2" onOpenChange={setIsOpen} open={isOpen}>
 			<div className="flex items-center justify-between space-x-4 px-4">
 				<h4 className="font-semibold text-sm">@peduarte starred 3 repositories</h4>
-				<CollapsibleTrigger asChild>
+				<CollapsibleTrigger asChild={true}>
 					<Button size="sm" variant="ghost">
 						<CaretSortIcon className="h-4 w-4" />
 						<span className="sr-only">Toggle</span>
@@ -81,7 +82,7 @@ export function Controlled(): ReactElement {
 	return (
 		<Collapsible className={rootClass} onOpenChange={setOpen} open={open}>
 			<CollapsibleTrigger className={triggerClass}>{open ? 'close' : 'open'}</CollapsibleTrigger>
-			<CollapsibleContent asChild className={contentClass}>
+			<CollapsibleContent asChild={true} className={contentClass}>
 				<article>Content 1</article>
 			</CollapsibleContent>
 		</Collapsible>
@@ -99,7 +100,7 @@ export function Chromatic(): ReactElement {
 			</Collapsible>
 
 			<h2>Open</h2>
-			<Collapsible className={rootClass} defaultOpen>
+			<Collapsible className={rootClass} defaultOpen={true}>
 				<CollapsibleTrigger className={triggerClass}>Trigger</CollapsibleTrigger>
 				<CollapsibleContent className={contentClass}>Content 1</CollapsibleContent>
 			</Collapsible>
@@ -112,13 +113,13 @@ export function Chromatic(): ReactElement {
 			</Collapsible>
 
 			<h2>Open</h2>
-			<Collapsible className={rootClass} open>
+			<Collapsible className={rootClass} open={true}>
 				<CollapsibleTrigger className={triggerClass}>Trigger</CollapsibleTrigger>
 				<CollapsibleContent className={contentClass}>Content 1</CollapsibleContent>
 			</Collapsible>
 
 			<h1>Disabled</h1>
-			<Collapsible className={rootClass} disabled>
+			<Collapsible className={rootClass} disabled={true}>
 				<CollapsibleTrigger className={triggerClass}>Trigger</CollapsibleTrigger>
 				<CollapsibleContent className={contentClass}>Content 1</CollapsibleContent>
 			</Collapsible>
@@ -131,13 +132,13 @@ export function Chromatic(): ReactElement {
 			</Collapsible>
 
 			<h2>Open</h2>
-			<Collapsible className={rootAttrClass} defaultOpen>
+			<Collapsible className={rootAttrClass} defaultOpen={true}>
 				<CollapsibleTrigger className={triggerAttrClass}>Trigger</CollapsibleTrigger>
 				<CollapsibleContent className={contentAttrClass}>Content 1</CollapsibleContent>
 			</Collapsible>
 
 			<h2>Disabled</h2>
-			<Collapsible className={rootAttrClass} defaultOpen disabled>
+			<Collapsible className={rootAttrClass} defaultOpen={true} disabled={true}>
 				<CollapsibleTrigger className={triggerAttrClass}>Trigger</CollapsibleTrigger>
 				<CollapsibleContent className={contentAttrClass}>Content 1</CollapsibleContent>
 			</Collapsible>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,4 +1,8 @@
-import { Button } from '@/ui/button.tsx'
+import type { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu'
+import type { Meta, StoryFn } from '@storybook/react'
+import { useCallback, useState } from 'react'
+
+import { Button } from '../../ui/button.tsx'
 import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
@@ -15,10 +19,7 @@ import {
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
-} from '@/ui/dropdown-menu'
-import type { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu'
-import type { Meta, StoryFn } from '@storybook/react'
-import { useCallback, useState } from 'react'
+} from '../../ui/dropdown-menu.tsx'
 
 const meta: Meta = {
 	component: DropdownMenu,
@@ -35,7 +36,7 @@ export const Checkboxes: StoryFn = () => {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
+			<DropdownMenuTrigger asChild={true}>
 				<Button variant="outline">Open</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent className="w-56">
@@ -46,7 +47,7 @@ export const Checkboxes: StoryFn = () => {
 				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					checked={showActivityBar}
-					disabled
+					disabled={true}
 					onCheckedChange={setShowActivityBar}
 				>
 					Activity Bar
@@ -79,7 +80,7 @@ export const RadioGroup: StoryFn = () => {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
+			<DropdownMenuTrigger asChild={true}>
 				<Button variant="outline">Open</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent className="w-56">
@@ -97,7 +98,7 @@ export const RadioGroup: StoryFn = () => {
 
 export const KitchenSink: StoryFn = () => (
 	<DropdownMenu>
-		<DropdownMenuTrigger asChild>
+		<DropdownMenuTrigger asChild={true}>
 			<Button variant="outline">Open</Button>
 		</DropdownMenuTrigger>
 		<DropdownMenuContent className="w-56">
@@ -143,7 +144,7 @@ export const KitchenSink: StoryFn = () => (
 			<DropdownMenuSeparator />
 			<DropdownMenuItem>GitHub</DropdownMenuItem>
 			<DropdownMenuItem>Support</DropdownMenuItem>
-			<DropdownMenuItem disabled>API</DropdownMenuItem>
+			<DropdownMenuItem disabled={true}>API</DropdownMenuItem>
 			<DropdownMenuSeparator />
 			<DropdownMenuItem>
 				Log out

--- a/packages/ui/src/components/layout/body.stories.tsx
+++ b/packages/ui/src/components/layout/body.stories.tsx
@@ -1,5 +1,6 @@
-import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import type { Meta, StoryObj } from '@storybook/react'
+
+import { Placeholder } from '../placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/footer.stories.tsx
+++ b/packages/ui/src/components/layout/footer.stories.tsx
@@ -1,5 +1,6 @@
-import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import type { Meta, StoryObj } from '@storybook/react'
+
+import { Placeholder } from '../placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/footer.stories.tsx
+++ b/packages/ui/src/components/layout/footer.stories.tsx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof meta>
 
 export const Footer: Story = {
 	decorators: [
-		Story => (
+		story => (
 			<Layout.Body
 				as="div"
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<Story />
+				<story />
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/layout/footer.stories.tsx
+++ b/packages/ui/src/components/layout/footer.stories.tsx
@@ -19,7 +19,7 @@ export const Footer: Story = {
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<story />
+				{story()}
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/layout/header.stories.tsx
+++ b/packages/ui/src/components/layout/header.stories.tsx
@@ -1,5 +1,6 @@
-import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import type { Meta, StoryObj } from '@storybook/react'
+
+import { Placeholder } from '../placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/header.stories.tsx
+++ b/packages/ui/src/components/layout/header.stories.tsx
@@ -17,7 +17,7 @@ export const Header: Story = {
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<story />
+				{story()}
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/layout/header.stories.tsx
+++ b/packages/ui/src/components/layout/header.stories.tsx
@@ -11,13 +11,13 @@ type Story = StoryObj<typeof meta>
 
 export const Header: Story = {
 	decorators: [
-		Story => (
+		story => (
 			<Layout.Body
 				as="div"
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<Story />
+				<story />
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/layout/layout.tsx
+++ b/packages/ui/src/components/layout/layout.tsx
@@ -1,9 +1,10 @@
+import { type ElementType, type JSX, forwardRef } from 'react'
+
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,
-} from '@/lib/polymorphic-component-prop.tsx'
-import { clsx } from '@/lib/utils.ts'
-import { type ElementType, type JSX, forwardRef } from 'react'
+} from '../../lib/polymorphic-component-prop.tsx'
+import { clsx } from '../../lib/utils.ts'
 
 const bodyName = 'Body'
 const Body = forwardRef(

--- a/packages/ui/src/components/layout/main.stories.tsx
+++ b/packages/ui/src/components/layout/main.stories.tsx
@@ -1,5 +1,6 @@
-import { Placeholder } from '@/components/placeholder/placeholder.tsx'
 import type { Meta, StoryObj } from '@storybook/react'
+
+import { Placeholder } from '../placeholder/placeholder.tsx'
 import { Layout } from './layout.tsx'
 
 const meta = {

--- a/packages/ui/src/components/layout/main.stories.tsx
+++ b/packages/ui/src/components/layout/main.stories.tsx
@@ -11,13 +11,13 @@ type Story = StoryObj<typeof meta>
 
 export const Main: Story = {
 	decorators: [
-		Story => (
+		story => (
 			<Layout.Body
 				as="div"
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<Story />
+				<story />
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/layout/main.stories.tsx
+++ b/packages/ui/src/components/layout/main.stories.tsx
@@ -17,7 +17,7 @@ export const Main: Story = {
 				className="border-violet-500 border-dashed bg-violet-200 text-center text-violet-500 text-xl"
 			>
 				Body
-				<story />
+				{story()}
 			</Layout.Body>
 		),
 	],

--- a/packages/ui/src/components/mode-toggle/mode-toggle.tsx
+++ b/packages/ui/src/components/mode-toggle/mode-toggle.tsx
@@ -1,17 +1,18 @@
-import { Icons } from '@/components/icons/icons.tsx'
-import { clsx } from '@/lib/utils.ts'
-import { Button } from '@/ui/button.tsx'
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from '@/ui/dropdown-menu.tsx'
 /* eslint-disable
 	react/jsx-pascal-case -- Reason need to modify the Icons component,
 	react/jsx-boolean-value  -- Reason biome is conflicting with this rule,
 	*/
 import { type ReactNode, memo, useMemo } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
+import { Button } from '../../ui/button.tsx'
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '../../ui/dropdown-menu.tsx'
+import { Icons } from '../icons/icons.tsx'
 
 export type Theme = 'dark' | 'light'
 

--- a/packages/ui/src/components/navigation-menu-toggle/hamburger-icon.tsx
+++ b/packages/ui/src/components/navigation-menu-toggle/hamburger-icon.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import type { ComponentProps, ReactElement } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 const baseClasses = clsx(
 	'absolute',

--- a/packages/ui/src/components/navigation-menu-toggle/navigation-menu-toggle.tsx
+++ b/packages/ui/src/components/navigation-menu-toggle/navigation-menu-toggle.tsx
@@ -1,7 +1,8 @@
-import { clsx, tv } from '@/lib/utils.ts'
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon'
 import type { ReactElement } from 'react'
 import { ToggleButton, type ToggleButtonProps, composeRenderProps } from 'react-aria-components'
+
+import { clsx, tv } from '../../lib/utils.ts'
 import { HamburgerIcon } from './hamburger-icon.tsx'
 
 const styles = tv({

--- a/packages/ui/src/components/navigation-menu/navigation-menu.stories.tsx
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.stories.tsx
@@ -1,5 +1,9 @@
-import { Icons } from '@/components/icons/icons.tsx'
-import { clsx } from '@/lib/utils.ts'
+import { Link } from '@remix-run/react'
+import type { Meta } from '@storybook/react'
+import type { ComponentPropsWithoutRef, ElementRef, ReactElement } from 'react'
+import { forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 import {
 	NavigationMenu,
 	NavigationMenuContent,
@@ -8,11 +12,8 @@ import {
 	NavigationMenuList,
 	NavigationMenuTrigger,
 	navigationMenuTriggerStyle,
-} from '@/ui/navigation-menu.tsx'
-import { Link } from '@remix-run/react'
-import type { Meta } from '@storybook/react'
-import type { ComponentPropsWithoutRef, ElementRef, ReactElement } from 'react'
-import { forwardRef } from 'react'
+} from '../../ui/navigation-menu.tsx'
+import { Icons } from '../icons/icons'
 
 const meta: Meta = {
 	component: NavigationMenu,
@@ -73,7 +74,7 @@ export function Default(): ReactElement {
 							)}
 						>
 							<li className="row-span-3">
-								<NavigationMenuLink asChild>
+								<NavigationMenuLink asChild={true}>
 									<a
 										className={clsx(
 											'flex',
@@ -151,7 +152,7 @@ const ListItem = forwardRef<ElementRef<'a'>, ComponentPropsWithoutRef<'a'>>(
 	({ className, title, children, ...props }, ref) => {
 		return (
 			<li>
-				<NavigationMenuLink asChild>
+				<NavigationMenuLink asChild={true}>
 					<a
 						className={clsx(
 							'block',

--- a/packages/ui/src/components/placeholder/placeholder.tsx
+++ b/packages/ui/src/components/placeholder/placeholder.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type JSX, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 const name = 'Placeholder'
 export const Placeholder = forwardRef<HTMLDivElement, JSX.IntrinsicElements['div']>(

--- a/packages/ui/src/components/skeleton/skeleton.stories.tsx
+++ b/packages/ui/src/components/skeleton/skeleton.stories.tsx
@@ -1,5 +1,6 @@
-import { Skeleton } from '@/ui/skeleton'
 import type { Meta, StoryFn } from '@storybook/react'
+
+import { Skeleton } from '../../ui/skeleton.tsx'
 
 const meta = {
 	component: Skeleton,

--- a/packages/ui/src/components/social/social-icon.tsx
+++ b/packages/ui/src/components/social/social-icon.tsx
@@ -1,5 +1,6 @@
-import { Icons } from '@/components/icons/icons.tsx'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { Icons } from '../icons/icons.tsx'
 
 export const IconMap = new Map([
 	['twitter', Icons.twitter],

--- a/packages/ui/src/components/social/social.tsx
+++ b/packages/ui/src/components/social/social.tsx
@@ -1,6 +1,7 @@
-import { clsx } from '@/lib/utils.ts'
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon'
 import type { JSX, ReactElement } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 import { SocialIcon } from './social-icon.tsx'
 
 function SocialLink({ className, children, ...props }: JSX.IntrinsicElements['a']): ReactElement {

--- a/packages/ui/src/components/suddenly-giovanni/suddenly-giovanni.tsx
+++ b/packages/ui/src/components/suddenly-giovanni/suddenly-giovanni.tsx
@@ -1,9 +1,10 @@
-import { clsx } from '@/lib/utils.ts'
-import { Avatar, AvatarFallback, AvatarImage } from '@/ui/avatar.tsx'
-import { Skeleton } from '@/ui/skeleton.tsx'
 import type { LinkProps } from '@remix-run/react'
 import { Link } from '@remix-run/react'
 import type { JSX } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
+import { Avatar, AvatarFallback, AvatarImage } from '../../ui/avatar.tsx'
+import { Skeleton } from '../../ui/skeleton.tsx'
 
 export function SuddenlyGiovanni({
 	className,

--- a/packages/ui/src/components/typography/a.tsx
+++ b/packages/ui/src/components/typography/a.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const A = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/blockquote.tsx
+++ b/packages/ui/src/components/typography/blockquote.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Blockquote = forwardRef<HTMLQuoteElement, ComponentPropsWithoutRef<'blockquote'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/code.tsx
+++ b/packages/ui/src/components/typography/code.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Code = forwardRef<HTMLElement, ComponentPropsWithoutRef<'code'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h1.tsx
+++ b/packages/ui/src/components/typography/h1.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const H1 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h1'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h2.tsx
+++ b/packages/ui/src/components/typography/h2.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const H2 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h2'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h3.tsx
+++ b/packages/ui/src/components/typography/h3.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const H3 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h3'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/h4.tsx
+++ b/packages/ui/src/components/typography/h4.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const H4 = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'h4'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/large.tsx
+++ b/packages/ui/src/components/typography/large.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Large = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/lead.tsx
+++ b/packages/ui/src/components/typography/lead.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Lead = forwardRef<HTMLHeadingElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/muted.tsx
+++ b/packages/ui/src/components/typography/muted.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Muted = forwardRef<HTMLParagraphElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/p.tsx
+++ b/packages/ui/src/components/typography/p.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const P = forwardRef<HTMLParagraphElement, ComponentPropsWithoutRef<'p'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/prose.stories.tsx
+++ b/packages/ui/src/components/typography/prose.stories.tsx
@@ -1,7 +1,8 @@
-import { clsx } from '@/lib/utils.ts'
 /* eslint-disable react/no-unescaped-entities -- Reason: storybook story */
 import type { Meta } from '@storybook/react'
 import type { ReactElement } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 const meta = {
 	title: 'components/typography/Prose',

--- a/packages/ui/src/components/typography/small.tsx
+++ b/packages/ui/src/components/typography/small.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Small = forwardRef<HTMLElement, ComponentPropsWithoutRef<'small'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/table.tsx
+++ b/packages/ui/src/components/typography/table.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Tr = forwardRef<HTMLTableRowElement, ComponentPropsWithoutRef<'tr'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/components/typography/ul.tsx
+++ b/packages/ui/src/components/typography/ul.tsx
@@ -1,5 +1,6 @@
-import { clsx } from '@/lib/utils.ts'
 import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+
+import { clsx } from '../../lib/utils.ts'
 
 export const Ul = forwardRef<HTMLUListElement, ComponentPropsWithoutRef<'ul'>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/ui/accordion.tsx
+++ b/packages/ui/src/ui/accordion.tsx
@@ -1,7 +1,8 @@
-import { clsx } from '@/lib/utils'
 import { Content, Header, Item, Root, Trigger } from '@radix-ui/react-accordion'
 import { ChevronDownIcon } from '@radix-ui/react-icons'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
+
+import { clsx } from '../lib/utils.ts'
 
 const Accordion = Root
 Accordion.displayName = Root.displayName
@@ -54,7 +55,7 @@ const AccordionContent = forwardRef<
 		ref={ref}
 		{...props}
 	>
-		<div className={clsx('pt-0 pb-4', className)}>{children}</div>
+		<div className={clsx('pb-4 pt-0', className)}>{children}</div>
 	</Content>
 ))
 AccordionContent.displayName = Content.displayName

--- a/packages/ui/src/ui/avatar.tsx
+++ b/packages/ui/src/ui/avatar.tsx
@@ -1,6 +1,7 @@
-import { clsx } from '@/lib/utils'
 import { Fallback, Image, Root } from '@radix-ui/react-avatar'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
+
+import { clsx } from '../lib/utils.ts'
 
 const Avatar = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, ...props }, ref) => (

--- a/packages/ui/src/ui/button.tsx
+++ b/packages/ui/src/ui/button.tsx
@@ -1,6 +1,7 @@
-import { type VariantProps, clsx, cva } from '@/lib/utils.ts'
 import { Slot } from '@radix-ui/react-slot'
 import { type ButtonHTMLAttributes, forwardRef } from 'react'
+
+import { type VariantProps, clsx, cva } from '../lib/utils.ts'
 
 const buttonVariants = cva(
 	clsx(

--- a/packages/ui/src/ui/dropdown-menu.tsx
+++ b/packages/ui/src/ui/dropdown-menu.tsx
@@ -1,4 +1,3 @@
-import { clsx } from '@/lib/utils.ts'
 import {
 	CheckboxItem,
 	Content,
@@ -24,6 +23,8 @@ import {
 	type ReactElement,
 	forwardRef,
 } from 'react'
+
+import { clsx } from '../lib/utils.ts'
 
 const DropdownMenu = Root
 const DropdownMenuTrigger = Trigger

--- a/packages/ui/src/ui/navigation-menu.tsx
+++ b/packages/ui/src/ui/navigation-menu.tsx
@@ -1,4 +1,3 @@
-import { clsx, cva } from '@/lib/utils.ts'
 import { ChevronDownIcon } from '@radix-ui/react-icons'
 import {
 	Content,
@@ -12,6 +11,8 @@ import {
 	Viewport,
 } from '@radix-ui/react-navigation-menu'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
+
+import { clsx, cva } from '../lib/utils.ts'
 
 const NavigationMenu = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, children, ...props }, ref) => (

--- a/packages/ui/src/ui/separator.tsx
+++ b/packages/ui/src/ui/separator.tsx
@@ -1,6 +1,7 @@
-import { clsx } from '@/lib/utils.ts'
 import { Root } from '@radix-ui/react-separator'
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react'
+
+import { clsx } from '../lib/utils.ts'
 
 export const Separator = forwardRef<ElementRef<typeof Root>, ComponentPropsWithoutRef<typeof Root>>(
 	({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (

--- a/packages/ui/src/ui/skeleton.tsx
+++ b/packages/ui/src/ui/skeleton.tsx
@@ -1,9 +1,10 @@
+import { type ElementType, forwardRef } from 'react'
+
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,
-} from '@/lib/polymorphic-component-prop.tsx'
-import { clsx } from '@/lib/utils.ts'
-import { type ElementType, forwardRef } from 'react'
+} from '../lib/polymorphic-component-prop.tsx'
+import { clsx } from '../lib/utils.ts'
 
 export const Skeleton = forwardRef(
 	<C extends ElementType = 'div'>(

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,9 +4,6 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"noEmit": true,
-		"paths": {
-			"@/*": ["src/*"]
-		},
 		"types": ["@total-typescript/ts-reset", "vite/client", "react", "react-dom"],
 		"useDefineForClassFields": true
 	},


### PR DESCRIPTION
This PR is centered around a strategic modification in the TypeScript configuration for the UI library. The key change involves removing the `@/` path alias from the `tsconfig.json` file.

CHANGE DETAILS:
- The `@/` path alias was previously utilized in the tsconfig for the UI library. It has been decisively removed in an effort to clear potential future conflicts or confusion related to path referencing.
- This significant change necessitated the refactoring of import paths in various UI packages from absolute to relative. This consequential update ensures the smooth functioning of our project without the `@/` alias.

Removal of the `@/` path alias and the consequent refactoring of the import paths present an improvement in our codebase structure, making it more straightforward and less prone to errors.