### PR TITLE
Disable eslint parameter reassignment rule in the context remix entry.server.tsx

### DIFF
--- a/apps/web/app/entry.server.tsx
+++ b/apps/web/app/entry.server.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign  -- Reason: This is how Remix defied the default entry.server */
 import { PassThrough } from 'node:stream'
 import type { AppLoadContext, EntryContext } from '@remix-run/node'
 import { createReadableStreamFromReadable } from '@remix-run/node'
@@ -55,6 +56,7 @@ function handleBotRequest(
 					reject(error)
 				},
 				onError(error: unknown) {
+					// biome-ignore lint/style/noParameterAssign: this is how Remix defined the default entry.server
 					responseStatusCode = 500
 					// Log streaming rendering errors from inside the shell.  Don't log
 					// errors encountered during initial shell rendering since they'll
@@ -101,6 +103,7 @@ function handleBrowserRequest(
 					reject(error)
 				},
 				onError(error: unknown) {
+					// biome-ignore lint/style/noParameterAssign: this is how Remix defined the default entry.server
 					responseStatusCode = 500
 					// Log streaming rendering errors from inside the shell.  Don't log
 					// errors encountered during initial shell rendering since they'll


### PR DESCRIPTION
Updates entry.server.tsx file to disable the 'no-parameter-reassign' rule in eslint. This adjustment is necessary due to the way Remix has defined the default entry.server. Also, suppressed linter warning for same reason in two onError functions. These modifications facilitate smoother code flow and operation.