### PR TITLE
CI / Automatically generate ephemeral “review apps”

### DIFF
--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -1,0 +1,47 @@
+name: 🚀 Deploy Review App
+
+on:
+  # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
+  pull_request:
+    types: [ opened, reopened, synchronize, closed ]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  # Set these to your Fly.io organization and preferred region.
+  FLY_REGION: ams
+  FLY_ORG: personal
+
+jobs:
+  review_app:
+    name: 🚀 Deploy app to Fly.io
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    # Only run one deployment at a time per PR.
+    concurrency:
+      group: pr-${{ github.event.number }}
+
+    # Deploying apps with this "review" environment allows the URL for the app to be displayed in the PR UI.
+    # Feel free to change the name of this environment.
+    environment:
+      name: review
+      # The script in the `deploy` sets the URL output for each review app.
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Get code
+        uses: actions/checkout@v4
+
+      - name: Deploy PR app to Fly.io
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.2.0
+        with:
+         config: apps/web/fly.toml
+
+      - name: Clean up GitHub environment
+        uses: strumwolf/delete-deployment-environment@v2
+        if: ${{ github.event.action == 'closed' }}
+        with:
+          # ⚠️ The provided token needs permission for admin write:org
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: pr-${{ github.event.number }}

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -38,5 +38,4 @@ jobs:
         uses: superfly/fly-pr-review-apps@1.2.0
         with:
           config: ./apps/web/fly.review.toml
-          image: ./apps/web/Dockerfile
           name: suddenlygiovanni-dev-pr-${{ github.event.number }}

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -36,7 +36,8 @@ jobs:
         id: deploy
         uses: superfly/fly-pr-review-apps@1.2.0
         with:
-         config: apps/web/fly.toml
+          config: ./apps/web/fly.toml
+          image: ./apps/web/Dockerfile
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -15,6 +15,7 @@ jobs:
   review_app:
     name: 🚀 Deploy app to Fly.io
     runs-on: ubuntu-latest
+    continue-on-error: true
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     # Only run one deployment at a time per PR.

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -36,8 +36,9 @@ jobs:
         id: deploy
         uses: superfly/fly-pr-review-apps@1.2.0
         with:
-          config: ./apps/web/fly.toml
+          config: ./apps/web/fly.review.toml
           image: ./apps/web/Dockerfile
+          name: suddenlygiovanni_dev-pr-${{ github.event.number }}
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           config: ./apps/web/fly.review.toml
           image: ./apps/web/Dockerfile
+          name: suddenlygiovanni-dev-pr-${{ github.event.number }}

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -6,7 +6,7 @@ on:
     types: [ opened, reopened, synchronize, closed ]
 
 env:
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_APP_REVIEW }}
   # Set these to your Fly.io organization and preferred region.
   FLY_REGION: ams
   FLY_ORG: personal
@@ -38,4 +38,3 @@ jobs:
         with:
           config: ./apps/web/fly.review.toml
           image: ./apps/web/Dockerfile
-          name: suddenlygiovanni_dev-pr-${{ github.event.number }}

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -38,4 +38,4 @@ jobs:
         uses: superfly/fly-pr-review-apps@1.2.0
         with:
           config: ./apps/web/fly.review.toml
-          name: suddenlygiovanni-dev-pr-${{ github.event.number }}
+          name: suddenlygiovanni-dev-${{ github.event.number }}

--- a/.github/workflows/deply-review.yml
+++ b/.github/workflows/deply-review.yml
@@ -39,11 +39,3 @@ jobs:
           config: ./apps/web/fly.review.toml
           image: ./apps/web/Dockerfile
           name: suddenlygiovanni_dev-pr-${{ github.event.number }}
-
-      - name: Clean up GitHub environment
-        uses: strumwolf/delete-deployment-environment@v2
-        if: ${{ github.event.action == 'closed' }}
-        with:
-          # ⚠️ The provided token needs permission for admin write:org
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: pr-${{ github.event.number }}

--- a/apps/web/fly.review.toml
+++ b/apps/web/fly.review.toml
@@ -13,6 +13,12 @@ memory = '1gb'
 cpu_kind = 'shared'
 cpus = 1
 
+[build]
+dockerfile = "Dockerfile"
+ignorefile = ".dockerignore"
+build-target = "production"
+
+
 [[services]]
 internal_port = 3000
 processes = ['app']

--- a/apps/web/fly.review.toml
+++ b/apps/web/fly.review.toml
@@ -1,0 +1,39 @@
+# fly.toml app configuration file generated for suddenlygiovanni-dev on 2024-03-03T02:43:25+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'suddenlygiovanni-dev'
+primary_region = 'ams'
+kill_signal = 'SIGINT'
+kill_timeout = 5
+
+[[vm]]
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1
+
+[[services]]
+internal_port = 3000
+processes = ['app']
+protocol = "tcp"
+
+	[services.concurrency]
+	hard_limit = 100
+	soft_limit = 80
+	type = "requests"
+
+	[http_service]
+	force_https = true
+	auto_stop_machines = true
+	auto_start_machines = true
+	min_machines_running = 0
+
+	[[services.ports]]
+	handlers = [ "http" ]
+	port = 80
+	force_https = true
+
+	[[services.ports]]
+	handlers = [ "tls", "http" ]
+	port = 443


### PR DESCRIPTION
The workflow will deploy a review app on each PR event like opening, updating, or closing. It also includes deploying the app to Fly.io and clean up GitHub environment when a PR gets closed.