### PR TITLE
CD - Fix  `internal_port` number in `fly.toml` to match Dockerfile 

### DIFF
--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -14,7 +14,7 @@ cpu_kind = 'shared'
 cpus = 1
 
 [[services]]
-internal_port = 3000
+internal_port = 8080
 processes = ['app']
 protocol = "tcp"
 


### PR DESCRIPTION
The internal_port number has been updated from 3000 to 8080 in the `fly .toml` file within the web module. This modification will direct the traffic to the new port as defined in `Dockerfile`.