### PR TITLE
CD - Tentatively fix `[..]` by  updating server's port to 5173

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -65,7 +65,7 @@ ENTRYPOINT ["sh"]
 FROM base AS production
 
 ENV NODE_ENV="production"
-ENV PORT="8080"
+ENV PORT="5173"
 ENV HOST="0.0.0.0"
 
 COPY --from=build --chown=node:node /home/node/pruned .
@@ -73,6 +73,6 @@ COPY --from=build --chown=node:node /home/node/apps/web/build ./build
 
 USER node
 
-EXPOSE 8080
+EXPOSE 5173
 
 CMD ["./node_modules/.bin/remix-serve", "./build/server/index.js"]

--- a/apps/web/fly.review.toml
+++ b/apps/web/fly.review.toml
@@ -19,7 +19,7 @@ ignorefile = ".dockerignore"
 build-target = "production"
 
 [[services]]
-internal_port = 8080
+internal_port = '5173'
 processes = ['app']
 protocol = "tcp"
 

--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -19,7 +19,7 @@ ignorefile = ".dockerignore"
 build-target = "production"
 
 [[services]]
-internal_port = 8080
+internal_port = "5173"
 processes = ['app']
 protocol = "tcp"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
       dockerfile: apps/web/Dockerfile
       target: production
     ports:
-      - "8080:8080"
+      - "5173:5173"
     init: true


### PR DESCRIPTION
The Dockerfile, fly.review.toml, fly.toml, and docker-compose.yml files were updated change the server's port to 5173. This establishes the updated port settings across the web modules and configurations.