### PR TITLE
CD / Upgrade Node version to >=22 across packages

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="docker-compose.yml">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="docker-compose.yml" />
+              <option name="relativePathToSchema" value="https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json" />
+              <option name="applicationDefined" value="true" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="docker-compose.yml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,7 @@
 GITHUB_TOKEN="MOCK_GITHUB_TOKEN"
 
+GITHUB_PACKAGES_TOKEN="MOCK_GITHUB_PACKAGES_TOKEN"
+
 # set this to false to prevent search engines from indexing the website
 # default to allow indexing for seo safety
 ALLOW_INDEXING="true"

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,7 +11,7 @@ RUN jq -r .packageManager package.json > pnpm-version.txt
 
 ENTRYPOINT ["sh"]
 
-FROM node:21-alpine3.19 AS base
+FROM node:22-alpine3.19 AS base
 
 LABEL authors="suddenlyGiovanni"
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,7 +71,7 @@
 		"vitest": "1.6.0"
 	},
 	"engines": {
-		"node": ">=21"
+		"node": ">=22"
 	},
 	"packageManager": "pnpm@9.1.0",
 	"config": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,13 @@ name: suddenlygiovannidev
 
 services:
   web:
+    env_file: apps/web/.env
     build:
       context: .
       dockerfile: apps/web/Dockerfile
       target: production
+      args:
+        GH_PACKAGES_TOKEN: ${GH_PACKAGES_TOKEN}
     ports:
       - "5173:5173"
     init: true

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "packageManager": "pnpm@9.1.0",
   "engines": {
-    "node": ">=21"
+    "node": ">=22"
   }
 }

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -29,6 +29,9 @@
 		"eslint-plugin-testing-library": "6.2.2",
 		"eslint-plugin-vitest": "0.4.1"
 	},
+	"engines": {
+		"node": ">=22"
+	},
 	"config": {
 		"scripty": {
 			"path": "../../scripts"

--- a/packages/config-prettier/package.json
+++ b/packages/config-prettier/package.json
@@ -19,6 +19,9 @@
 		"@suddenlygiovanni/config-typescript": "workspace:*",
 		"prettier-plugin-tailwindcss": "0.5.14"
 	},
+	"engines": {
+		"node": ">=22"
+	},
 	"config": {
 		"scripty": {
 			"path": "../../scripts"

--- a/packages/open-graph-protocol/package.json
+++ b/packages/open-graph-protocol/package.json
@@ -37,6 +37,9 @@
 		"lint": "scripty src/",
 		"typecheck": "scripty"
 	},
+	"engines": {
+		"node": ">=22"
+	},
 	"packageManager": "pnpm@9.1.0",
 	"config": {
 		"scripty": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,6 +78,9 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"engines": {
+		"node": ">=22"
+	},
 	"packageManager": "pnpm@9.1.0",
 	"config": {
 		"scripty": {


### PR DESCRIPTION
All package.json files along with Dockerfile have been updated to reflect the minimum required Node version >=22. This update affects all projects, with necessary adjustments made to the "engines" field and the
 base image in Dockerfile.