### PR TITLE
Apps Web / Fix CSS class names in skills.tsx

### DIFF
--- a/apps/web/app/routes/resume/skills.tsx
+++ b/apps/web/app/routes/resume/skills.tsx
@@ -38,7 +38,7 @@ export const Skills = memo(function Skills({
 			<T.h2>Skills</T.h2>
 
 			<Button
-				className="absolute·top-0·right-0·rounded-full"
+				className="absolute top-0 right-0 rounded-full"
 				onClick={toggleSkillsAccordion}
 				size="icon"
 				variant="ghost"


### PR DESCRIPTION
An update was made to the skills.tsx file, specifically to the CSS class
 names for the "Skills" button. The update replaced the incorrect
 middot-separated class names with the correct space-separated class
 format.