### PR TITLE
Update Node.js base image to alpine3.20

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,7 +11,7 @@ RUN jq -r .packageManager package.json > pnpm-version.txt
 
 ENTRYPOINT ["sh"]
 
-FROM node:22-alpine3.19 AS base
+FROM node:22-alpine3.20 AS base
 
 LABEL authors="suddenlyGiovanni"
 


### PR DESCRIPTION
Upgrade Node.js base image from alpine3.19 to alpine3.20 in Dockerfile. This ensures we are using the latest patch release with the most recent security and bug fixes.