### PR TITLE
CI: disable telemetry and tracking in Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -47,6 +47,9 @@ ENTRYPOINT ["sh"]
 
 FROM base AS build
 
+ENV TURBO_TELEMETRY_DISABLED=1
+ENV DO_NOT_TRACK=1
+
 # pnpm fetch does require only lockfile + .npmrc
 COPY --from=builder /home/node/out/json/pnpm-lock.yaml .
 COPY --from=builder /home/node/out/json/.npmrc .


### PR DESCRIPTION
Added environment variables to disable telemetry and tracking. This ensures that the build process is more private and minimizes unnecessary network usage during the Docker build.