### PR TITLE
feat(ui): replace `clsx` with custom scoped package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
 		}
 	},
 	"dependencies": {
+		"@nick/clsx": "npm:@jsr/nick__clsx@0.3.1",
 		"@radix-ui/react-accessible-icon": "1.1.0",
 		"@radix-ui/react-accordion": "1.2.1",
 		"@radix-ui/react-avatar": "1.1.1",
@@ -16,9 +17,9 @@
 		"@radix-ui/react-separator": "1.1.0",
 		"@radix-ui/react-slot": "1.1.0",
 		"@radix-ui/react-switch": "1.1.1",
-		"react-router": "7.0.2",
 		"react": "18.3.1",
 		"react-aria-components": "1.5.0",
+		"react-router": "7.0.2",
 		"tailwind-variants": "0.3.0"
 	},
 	"devDependencies": {
@@ -40,7 +41,6 @@
 		"@vitejs/plugin-react-swc": "3.7.2",
 		"autoprefixer": "10.4.20",
 		"class-variance-authority": "0.7.1",
-		"clsx": "2.1.1",
 		"postcss": "8.4.49",
 		"storybook": "8.4.6",
 		"tailwind-merge": "2.5.5",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,8 +1,14 @@
-import { type ClassValue, clsx as _clsx } from 'clsx'
+import * as Clsx from '@nick/clsx'
 import { twMerge } from 'tailwind-merge'
 
-export function clsx<T extends ClassValue[]>(...inputs: T): string {
-	return twMerge(_clsx(inputs))
+declare module '@nick/clsx' {
+	export type ClassValues = readonly Clsx.ClassValue[]
+}
+
+export function clsx<const T extends Clsx.ClassValues>(...classes: [...T]): Clsx.Clsx<T>
+export function clsx(...classes: Clsx.ClassValues): string
+export function clsx(...classes: Clsx.ClassValues): string {
+	return twMerge(Clsx.clsx(classes))
 }
 
 // biome-ignore lint/performance/noBarrelFile: need a barrel file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@nick/clsx':
+        specifier: npm:@jsr/nick__clsx@0.3.1
+        version: '@jsr/nick__clsx@0.3.1'
       '@radix-ui/react-accessible-icon':
         specifier: 1.1.0
         version: 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -288,9 +291,6 @@ importers:
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
       postcss:
         specifier: 8.4.49
         version: 8.4.49
@@ -965,6 +965,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jsr/nick__clsx@0.3.1':
+    resolution: {integrity: sha512-74Wg5ed6OdEzKAoVv1FcVBwaiKIK0LmLPHXUWH58bxf+/6EPGhUi2HtMho77972n4XagAUzFVf/aUKcVzU6UIg==, tarball: https://npm.jsr.io/~/11/@jsr/nick__clsx/0.3.1.tgz}
 
   '@jsr/std__yaml@1.0.5':
     resolution: {integrity: sha512-jbh2xwnja+ar+7NE0oDTlbST1WW29dAQOKX8+1DZgdT54NVt9lZ9YVDrzh4uP1w6ZHVirtY0z99BSym0v+Zh4Q==, tarball: https://npm.jsr.io/~/11/@jsr/std__yaml/1.0.5.tgz}
@@ -3469,7 +3472,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3540,7 +3542,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4363,6 +4364,9 @@ packages:
 
   set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5502,6 +5506,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jsr/nick__clsx@0.3.1': {}
 
   '@jsr/std__yaml@1.0.5': {}
 
@@ -9336,7 +9342,7 @@ snapshots:
       '@types/cookie': 0.6.0
       cookie: 1.0.2
       react: 18.3.1
-      set-cookie-parser: 2.6.0
+      set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
@@ -9520,6 +9526,8 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.6.0: {}
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
Replace the `clsx` package with a custom scoped version `@nick/clsx`.
 This change involved updating the imports and usage in `utils.ts`,
 as well as modifying the dependencies in `package.json` and
 `pnpm-lock.yaml`. This provides more flexibility and customization
 for the `clsx` functionality.