### PR TITLE
chore(package): update pnpm to version 9.15.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
 		"node": ">=22.10"
 	},
 	"name": "@suddenlygiovanni/web",
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+	"packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
 	"private": true,
 	"scripts": {
 		"build": "react-router build",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"license": "UNLICENSED",
 	"name": "@suddenlygiovanni/root",
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+	"packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
 	"private": true,
 	"scripts": {
 		"build": "turbo build --log-order=grouped",

--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -12,7 +12,7 @@
 		"@tsconfig/vite-react": "3.4.0"
 	},
 	"name": "@suddenlygiovanni/config-typescript",
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+	"packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
 	"peerDependencies": {
 		"typescript": "5.7.2"
 	},

--- a/packages/open-graph-protocol/package.json
+++ b/packages/open-graph-protocol/package.json
@@ -34,7 +34,7 @@
 	],
 	"license": "MIT",
 	"name": "@suddenlygiovanni/open-graph-protocol",
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+	"packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
 	"scripts": {
 		"clean": "scripty",
 		"format": "biome check --vcs-enabled=true --vcs-use-ignore-file=true --vcs-root='../../' --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true .",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,7 +58,7 @@
 		"./hooks/*": "./src/hooks/*"
 	},
 	"name": "@suddenlygiovanni/ui",
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+	"packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
 	"peerDependencies": {
 		"react": "18.3.1"
 	},


### PR DESCRIPTION
Updated the package manager version to pnpm 9.15.0 across all modules . This ensures compatibility with the latest features and fixes provided by the package manager. Make sure all team members are using
 the updated pnpm version to avoid any inconsistencies.