### PR TITLE
Fix missing .npmrc configuration in GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,7 +39,4 @@ runs:
 
     - name: 🧩 Install dependencies
       shell: bash
-      env:
-        NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
-#        NODE_AUTH_TOKEN: ${{ inputs.github_packages_token }}
       run: pnpm install --recursive --frozen-lockfile --prod=false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,4 +39,6 @@ runs:
 
     - name: 🧩 Install dependencies
       shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.github_packages_token }}
       run: pnpm install --recursive --frozen-lockfile --prod=false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,11 @@ runs:
         node-version-file: '.nvmrc'
         registry-url: 'https://npm.pkg.github.com'
 
+    - name: Configure .npmrc
+      shell: bash
+      run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.NODE_AUTH_TOKEN }}" >> ~/.npmrc
+
+
     - name: 🗂️ Install pnpm
       uses: pnpm/action-setup@v4
       with:
@@ -36,5 +41,5 @@ runs:
       shell: bash
       env:
         NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
-        NODE_AUTH_TOKEN: ${{ inputs.github_packages_token }}
+#        NODE_AUTH_TOKEN: ${{ inputs.github_packages_token }}
       run: pnpm install --recursive --frozen-lockfile --prod=false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Configure .npmrc
       shell: bash
-      run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.NODE_AUTH_TOKEN }}" >> ~/.npmrc
+      run: echo "//npm.pkg.github.com/:_authToken=${{ inputs.github_packages_token }}" >> ~/.npmrc
 
 
     - name: 🗂️ Install pnpm

--- a/.npmrc
+++ b/.npmrc
@@ -181,6 +181,5 @@ dedupe-injected-deps = true
 enable-pre-post-scripts = false
 
 ; ___Registry & Authentication Settings___
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
 @jsr:registry=https://npm.jsr.io
 @suddenlygiovanni:registry=https://npm.pkg.github.com


### PR DESCRIPTION
This pull request includes changes to the `.github/actions/setup/action.yml` and `.npmrc` files to improve the setup and configuration of npm and pnpm.

Changes to npm and pnpm setup:

* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530R16-R20): Added a step to configure `.npmrc` with the GitHub Packages token.
* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L38): Removed the `NPM_CONFIG_USERCONFIG` environment variable from the dependencies installation step.
* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL184): Removed the line setting the npm authentication token for GitHub Packages.