### PR TITLE
Fix  `@suddenlyGiovanni/resume` monorepo migration braking changes

### DIFF
--- a/apps/web/src/services/resume-repository.ts
+++ b/apps/web/src/services/resume-repository.ts
@@ -162,11 +162,11 @@ function getResumeFile({
 				 * - fail
 				 * - notify
 				 */
-				return data.type === 'file' && data.name === path && data.path === path
+				return data.type === 'file' && data.path === path
 					? Effect.succeed(data)
 					: Effect.fail(
 							new InvalidDataError({
-								message: `Expected a file matching the correct path and name; got ${data.type}`,
+								message: `Expected a file matching the correct path and name; got "${data.type}"`,
 							}),
 						)
 			}),
@@ -199,7 +199,7 @@ const decodeResume = Schema.decode(parseYml(Resume))
 const decodePackageJson = Schema.decode(Schema.parseJson(Package))
 
 function getResume(
-	ref = 'main',
+	ref = 'monorepo',
 ): Effect.Effect<
 	{ meta: typeof Meta.Type; resume: typeof Resume.Type },
 	DecodingError | RequestError | InvalidDataError | ParseError,
@@ -211,8 +211,8 @@ function getResume(
 	return Effect.gen(function* () {
 		const [resumeFile, packageFile] = yield* Effect.all(
 			[
-				getResumeFile({ owner, path: 'resume.yml', ref, repo }),
-				getResumeFile({ owner, path: 'package.json', ref, repo }),
+				getResumeFile({ owner, path: 'packages/resume/src/resume.yml', ref, repo }),
+				getResumeFile({ owner, path: 'packages/resume/package.json', ref, repo }),
 			],
 			{ concurrency: 2 },
 		)

--- a/apps/web/src/services/resume-repository.ts
+++ b/apps/web/src/services/resume-repository.ts
@@ -199,7 +199,7 @@ const decodeResume = Schema.decode(parseYml(Resume))
 const decodePackageJson = Schema.decode(Schema.parseJson(Package))
 
 function getResume(
-	ref = 'monorepo',
+	ref = 'main',
 ): Effect.Effect<
 	{ meta: typeof Meta.Type; resume: typeof Resume.Type },
 	DecodingError | RequestError | InvalidDataError | ParseError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3861,7 +3861,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3973,7 +3972,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}


### PR DESCRIPTION
Adapts to the `@suddenlyGiovanni/resume` monorepo migration braking changes.

This pull request includes changes to the `resume-repository.ts` file to simplify and correct the file path checks, and updates to the `pnpm-lock.yaml` file to remove deprecated warnings.

Changes in `resume-repository.ts`:

* Simplified the file path check by removing the redundant name comparison in the `getResumeFile` function.
* Updated the paths for the `resume.yml` and `package.json` files in the `getResume` function to their correct locations.

Updates in `pnpm-lock.yaml`:

* Removed deprecated warnings for the `glob` and `inflight` packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3864) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3976)