### PR TITLE
chore: Upgrade dependency to @suddenlygiovanni/schema-resume

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
 		"@react-router/node": "7.1.1",
 		"@std/yaml": "npm:@jsr/std__yaml@1.0.5",
 		"@suddenlygiovanni/open-graph-protocol": "workspace:*",
-		"@suddenlygiovanni/resume": "13.3.1",
+		"@suddenlygiovanni/schema-resume": "14.0.0",
 		"@suddenlygiovanni/ui": "workspace:*",
 		"compression": "^1.7.5",
 		"cookie": "1.0.2",
@@ -36,6 +36,7 @@
 		"@react-router/dev": "7.1.1",
 		"@suddenlygiovanni/config-typescript": "workspace:*",
 		"@suddenlygiovanni/eslint-config": "workspace:*",
+
 		"@tailwindcss/typography": "0.5.15",
 		"@tailwindcss/vite": "4.0.0-beta.8",
 		"@total-typescript/ts-reset": "0.6.1",

--- a/apps/web/src/models/resume/meta/meta.ts
+++ b/apps/web/src/models/resume/meta/meta.ts
@@ -1,4 +1,4 @@
-import { TrimmedNonEmpty, UrlString } from '@suddenlygiovanni/resume/schema-primitive'
+import { TrimmedNonEmpty, UrlString } from '@suddenlygiovanni/schema-resume'
 import { Schema } from 'effect'
 
 export class Meta extends Schema.Class<Meta>('Meta')({

--- a/apps/web/src/routes/resume/basics.tsx
+++ b/apps/web/src/routes/resume/basics.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Link } from 'react-router'
 
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { SocialIcon } from '@suddenlygiovanni/ui/components/social/social-icon.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'

--- a/apps/web/src/routes/resume/education.tsx
+++ b/apps/web/src/routes/resume/education.tsx
@@ -1,7 +1,7 @@
 import { Either, pipe } from 'effect'
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { clsx } from '@suddenlygiovanni/ui/lib/utils.ts'

--- a/apps/web/src/routes/resume/experience.tsx
+++ b/apps/web/src/routes/resume/experience.tsx
@@ -1,4 +1,4 @@
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { Either, Option } from 'effect'
 import type { ReactElement } from 'react'
 

--- a/apps/web/src/routes/resume/experiences.tsx
+++ b/apps/web/src/routes/resume/experiences.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { Accordion } from '@suddenlygiovanni/ui/ui/accordion.tsx'

--- a/apps/web/src/routes/resume/interests.tsx
+++ b/apps/web/src/routes/resume/interests.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 
 import { generateDjb2Hash } from '~/routes/resume/generate-djb2-hash.ts'

--- a/apps/web/src/routes/resume/languages.tsx
+++ b/apps/web/src/routes/resume/languages.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 
-import type * as Model from '@suddenlygiovanni/resume/schema-resume'
+import type * as Model from '@suddenlygiovanni/schema-resume'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 
 export function Languages({

--- a/apps/web/src/routes/resume/skills.tsx
+++ b/apps/web/src/routes/resume/skills.tsx
@@ -1,7 +1,7 @@
 import { Option } from 'effect'
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type { Skill as ResumeSkill } from '@suddenlygiovanni/resume/schema-resume'
+import type { Skill as ResumeSkill } from '@suddenlygiovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { clsx } from '@suddenlygiovanni/ui/lib/utils.ts'

--- a/apps/web/src/services/resume-repository.ts
+++ b/apps/web/src/services/resume-repository.ts
@@ -1,4 +1,4 @@
-import { Resume } from '@suddenlygiovanni/resume/schema-resume'
+import { Resume } from '@suddenlygiovanni/schema-resume'
 import { Console, Data, Effect, Layer, Option, Schema } from 'effect'
 import type { ParseError } from 'effect/ParseResult'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,9 @@ importers:
       '@suddenlygiovanni/open-graph-protocol':
         specifier: workspace:*
         version: link:../../packages/open-graph-protocol
-      '@suddenlygiovanni/resume':
-        specifier: 13.3.1
-        version: 13.3.1
+      '@suddenlygiovanni/schema-resume':
+        specifier: 14.0.0
+        version: 14.0.0
       '@suddenlygiovanni/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -2615,9 +2615,8 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@suddenlygiovanni/resume@13.3.1':
-    resolution: {integrity: sha512-wRYoWU/hdY9/jMqfd12IVlWpLZM4UawgorCO14Ug87jcW2d/eOoh0FRtB21VPkdBumi4oyLb87tlB2kJg9qOSA==, tarball: https://npm.pkg.github.com/download/@suddenlygiovanni/resume/13.3.1/4544dbcedbec580cde8180901ece97a96f2c8975}
-    engines: {node: '>=23'}
+  '@suddenlygiovanni/schema-resume@14.0.0':
+    resolution: {integrity: sha512-YPKWvddtDHodiAN37BDZohwN0+rI7/xAgtb1IuQAbuwxgC1fFmamdkwzpSU9IfK5A5gVl+rZfP2UcRUS9fGc4A==, tarball: https://npm.pkg.github.com/download/@suddenlygiovanni/schema-resume/14.0.0/cc07e73267ca26efb208404c9150f5ed70020b86}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -8424,7 +8423,7 @@ snapshots:
     dependencies:
       storybook: 8.4.7(prettier@2.8.8)
 
-  '@suddenlygiovanni/resume@13.3.1': {}
+  '@suddenlygiovanni/schema-resume@14.0.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
The import from `@suddenlygiovanni/resume` was switched to `@suddenlygiovanni/schema-resume` to ensure compatibility with the latest schema changes. Package.json and pnpm-lock.yaml were updated accordingly.