### PR TITLE
chore(web): update @suddenlygiovanni/schema-resume to 14.0.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
 		"@react-router/node": "7.1.1",
 		"@std/yaml": "npm:@jsr/std__yaml@1.0.5",
 		"@suddenlygiovanni/open-graph-protocol": "workspace:*",
-		"@suddenlygiovanni/schema-resume": "14.0.0",
+		"@suddenlygiovanni/schema-resume": "14.0.1",
 		"@suddenlygiovanni/ui": "workspace:*",
 		"compression": "^1.7.5",
 		"cookie": "1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/open-graph-protocol
       '@suddenlygiovanni/schema-resume':
-        specifier: 14.0.0
-        version: 14.0.0
+        specifier: 14.0.1
+        version: 14.0.1(effect@3.12.0)
       '@suddenlygiovanni/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -2615,8 +2615,10 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@suddenlygiovanni/schema-resume@14.0.0':
-    resolution: {integrity: sha512-YPKWvddtDHodiAN37BDZohwN0+rI7/xAgtb1IuQAbuwxgC1fFmamdkwzpSU9IfK5A5gVl+rZfP2UcRUS9fGc4A==, tarball: https://npm.pkg.github.com/download/@suddenlygiovanni/schema-resume/14.0.0/cc07e73267ca26efb208404c9150f5ed70020b86}
+  '@suddenlygiovanni/schema-resume@14.0.1':
+    resolution: {integrity: sha512-vwvNL6a2FffdpYzO5R0IOty1clvXYn8UaueGzkYSiRLanR081HBIiqfLhT24yuPqGnoHTLbfS4CYf8aaFvCTIQ==, tarball: https://npm.pkg.github.com/download/@suddenlygiovanni/schema-resume/14.0.1/f5d59eeae75bfb6b82b871dc775d943086eb1b29}
+    peerDependencies:
+      effect: ~3.12.0
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -8423,7 +8425,9 @@ snapshots:
     dependencies:
       storybook: 8.4.7(prettier@2.8.8)
 
-  '@suddenlygiovanni/schema-resume@14.0.0': {}
+  '@suddenlygiovanni/schema-resume@14.0.1(effect@3.12.0)':
+    dependencies:
+      effect: 3.12.0
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
Upgrade @suddenlygiovanni/schema-resume dependency to version 14.0.1. This update includes the addition of a peer dependency on `effect@~3.12.0`. Adjusted the lock file accordingly to reflect the changes.