### PR TITLE
chore(web): update schema-resume dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,8 @@
 		"@octokit/request-error": "6.1.6",
 		"@react-router/node": "7.1.3",
 		"@std/yaml": "npm:@jsr/std__yaml@1.0.5",
+		"@suddenly-giovanni/schema-resume": "npm:@jsr/suddenly-giovanni__schema-resume@0.0.2",
 		"@suddenlygiovanni/open-graph-protocol": "workspace:*",
-		"@suddenlygiovanni/schema-resume": "14.0.3",
 		"@suddenlygiovanni/ui": "workspace:*",
 		"compression": "^1.7.5",
 		"cookie": "1.0.2",
@@ -36,7 +36,6 @@
 		"@react-router/dev": "7.1.3",
 		"@suddenlygiovanni/config-typescript": "workspace:*",
 		"@suddenlygiovanni/eslint-config": "workspace:*",
-
 		"@tailwindcss/typography": "0.5.16",
 		"@tailwindcss/vite": "4.0.0",
 		"@total-typescript/ts-reset": "0.6.1",

--- a/apps/web/src/models/resume/meta/meta.ts
+++ b/apps/web/src/models/resume/meta/meta.ts
@@ -1,4 +1,4 @@
-import { TrimmedNonEmpty, UrlString } from '@suddenlygiovanni/schema-resume'
+import { TrimmedNonEmpty, UrlString } from '@suddenly-giovanni/schema-resume'
 import { Schema } from 'effect'
 
 export class Meta extends Schema.Class<Meta>('Meta')({

--- a/apps/web/src/routes/resume/basics.tsx
+++ b/apps/web/src/routes/resume/basics.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Link } from 'react-router'
 
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { SocialIcon } from '@suddenlygiovanni/ui/components/social/social-icon.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'

--- a/apps/web/src/routes/resume/education.tsx
+++ b/apps/web/src/routes/resume/education.tsx
@@ -1,7 +1,7 @@
 import { Either, pipe } from 'effect'
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { clsx } from '@suddenlygiovanni/ui/lib/utils.ts'

--- a/apps/web/src/routes/resume/experience.tsx
+++ b/apps/web/src/routes/resume/experience.tsx
@@ -1,4 +1,4 @@
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { Either, Option } from 'effect'
 import type { ReactElement } from 'react'
 

--- a/apps/web/src/routes/resume/experiences.tsx
+++ b/apps/web/src/routes/resume/experiences.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { Accordion } from '@suddenlygiovanni/ui/ui/accordion.tsx'

--- a/apps/web/src/routes/resume/interests.tsx
+++ b/apps/web/src/routes/resume/interests.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 
 import { generateDjb2Hash } from '~/routes/resume/generate-djb2-hash.ts'

--- a/apps/web/src/routes/resume/languages.tsx
+++ b/apps/web/src/routes/resume/languages.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 
-import type * as Model from '@suddenlygiovanni/schema-resume'
+import type * as Model from '@suddenly-giovanni/schema-resume'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 
 export function Languages({

--- a/apps/web/src/routes/resume/skills.tsx
+++ b/apps/web/src/routes/resume/skills.tsx
@@ -1,7 +1,7 @@
 import { Option } from 'effect'
 import { type MouseEventHandler, type ReactElement, useState } from 'react'
 
-import type { Skill as ResumeSkill } from '@suddenlygiovanni/schema-resume'
+import type { Skill as ResumeSkill } from '@suddenly-giovanni/schema-resume'
 import { Icons } from '@suddenlygiovanni/ui/components/icons/icons.tsx'
 import { T } from '@suddenlygiovanni/ui/components/typography/typography.tsx'
 import { clsx } from '@suddenlygiovanni/ui/lib/utils.ts'

--- a/apps/web/src/services/resume-repository.ts
+++ b/apps/web/src/services/resume-repository.ts
@@ -1,4 +1,4 @@
-import { Resume } from '@suddenlygiovanni/schema-resume'
+import { Resume } from '@suddenly-giovanni/schema-resume'
 import { Console, Data, Effect, Layer, Option, Schema } from 'effect'
 import type { ParseError } from 'effect/ParseResult'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,12 +58,12 @@ importers:
       '@std/yaml':
         specifier: npm:@jsr/std__yaml@1.0.5
         version: '@jsr/std__yaml@1.0.5'
+      '@suddenly-giovanni/schema-resume':
+        specifier: npm:@jsr/suddenly-giovanni__schema-resume@0.0.2
+        version: '@jsr/suddenly-giovanni__schema-resume@0.0.2'
       '@suddenlygiovanni/open-graph-protocol':
         specifier: workspace:*
         version: link:../../packages/open-graph-protocol
-      '@suddenlygiovanni/schema-resume':
-        specifier: 14.0.3
-        version: 14.0.3(effect@3.12.7)
       '@suddenlygiovanni/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -511,7 +511,6 @@ packages:
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1021,6 +1020,9 @@ packages:
 
   '@jsr/std__yaml@1.0.5':
     resolution: {integrity: sha512-jbh2xwnja+ar+7NE0oDTlbST1WW29dAQOKX8+1DZgdT54NVt9lZ9YVDrzh4uP1w6ZHVirtY0z99BSym0v+Zh4Q==, tarball: https://npm.jsr.io/~/11/@jsr/std__yaml/1.0.5.tgz}
+
+  '@jsr/suddenly-giovanni__schema-resume@0.0.2':
+    resolution: {integrity: sha512-W0Cf7rJLErhAm7+5XdjNqDDapchqRUDFjhNCIO9s1N2t9sp9soQtnopKMVYRlda/Xo7+7W6JQ3+q5Es0Y46uAg==, tarball: https://npm.jsr.io/~/11/@jsr/suddenly-giovanni__schema-resume/0.0.2.tgz}
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -2673,11 +2675,6 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@suddenlygiovanni/schema-resume@14.0.3':
-    resolution: {integrity: sha512-xXNXGC5nC738hsVEFYzH/qaFLiMMemeyVjcUuYZ0obzSDyX1qvSeY7+5uRFVDLh3zezi4mZnAwHbG1bZYRUipg==, tarball: https://npm.pkg.github.com/download/@suddenlygiovanni/schema-resume/14.0.3/23973b13120853caccdf8720666ca19a8b6e4f91}
-    peerDependencies:
-      effect: ~3.12.7
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -3926,7 +3923,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4038,7 +4034,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6428,6 +6423,10 @@ snapshots:
 
   '@jsr/std__yaml@1.0.5': {}
 
+  '@jsr/suddenly-giovanni__schema-resume@0.0.2':
+    dependencies:
+      effect: 3.12.7
+
   '@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -8588,10 +8587,6 @@ snapshots:
   '@storybook/theming@8.5.1(storybook@8.5.1(prettier@2.8.8))':
     dependencies:
       storybook: 8.5.1(prettier@2.8.8)
-
-  '@suddenlygiovanni/schema-resume@14.0.3(effect@3.12.7)':
-    dependencies:
-      effect: 3.12.7
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
This pull request includes updates to the `@suddenlygiovanni/schema-resume` package across multiple files and the removal of deprecated dependencies in the `pnpm-lock.yaml` file.

### Updates to `@suddenlygiovanni/schema-resume` package:

* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R16-L17): Updated `@suddenlygiovanni/schema-resume` to `@suddenly-giovanni/schema-resume` with version `0.0.2`.
* [`apps/web/src/models/resume/meta/meta.ts`](diffhunk://#diff-aa21cd7146660229c4d3a0f2d5cc939a1eca73121a9a17e5d955970a337732bcL1-R1): Changed import paths for `TrimmedNonEmpty` and `UrlString` from `@suddenlygiovanni/schema-resume` to `@suddenly-giovanni/schema-resume`.
* [`apps/web/src/routes/resume/*`](diffhunk://#diff-1e68bd8f48a7b0ab4717005c0876e00f58dcdb702a88556266591d9d4d795855L4-R4): Updated import paths for `Model` and `Skill` from `@suddenlygiovanni/schema-resume` to `@suddenly-giovanni/schema-resume`. [[1]](diffhunk://#diff-1e68bd8f48a7b0ab4717005c0876e00f58dcdb702a88556266591d9d4d795855L4-R4) [[2]](diffhunk://#diff-99891cdfa41857414719eab455b0af310eaaf22d748ce18464c10ba89571b015L4-R4) [[3]](diffhunk://#diff-cb5ffdbff0605b3a7ef0d84cd5841717604547aa35c0d51498722f0d30867ae0L1-R1) [[4]](diffhunk://#diff-c02a24cfa87e55c34f2b183aedf5e46b33150132cc6fbddfb8f04a59f17e4df6L3-R3) [[5]](diffhunk://#diff-f0f201e971f3001f95f73bfbf81e41210daa2f0801c9049790451390ce7a1339L3-R3) [[6]](diffhunk://#diff-c52b0e63c6d05200ca4eabd4a35b0f5347125659f5fe566b5f056b1cd4b8f398L3-R3) [[7]](diffhunk://#diff-86df122a259c699f091c145704ec20b560abd93ffd4e212645dbeb705683eb04L4-R4)
* [`apps/web/src/services/resume-repository.ts`](diffhunk://#diff-ca7e97eeb0c4e951b20a45c34ce9d8333ebe54b43416cebc1ad927a17f8da7bbL1-R1): Changed import path for `Resume` from `@suddenlygiovanni/schema-resume` to `@suddenly-giovanni/schema-resume`.

### Removal of deprecated dependencies:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR61-L66): Removed deprecated dependencies and updated package versions accordingly. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR61-L66) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL514) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1024-R1026) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2676-L2680) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3929) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4041) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6426-R6429) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8592-L8595)Replaced deprecated `@suddenlygiovanni/schema-resume` with scoped `@suddenly-giovanni/schema-resume`. Updated all affected imports across the module and synchronized changes in `package.json` and `pnpm-lock.yaml`.