### PR TITLE
Add GitHub workflow to lint PR titles

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,35 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            monorepo
+            ci
+            packages/app
+            packages/ui
+            packages/open-graph-protocol
+            tools/eslint
+            tools/tailwind
+            tools/typescript
+          requireScope: true
+          ignoreLabels: |
+            dependencies
+          wip: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint pull request titles. The workflow ensures that PR titles follow semantic conventions and are properly categorized.

Key changes include:

* Added a new GitHub Actions workflow file `.github/workflows/lint-pr-title.yml` to validate PR titles. The workflow is triggered on various pull request events and uses the `amannn/action-semantic-pull-request` action to enforce title conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Implemented an automated process that validates pull request titles against standardized conventions. This enhancement helps ensure consistency across contributions by enforcing proper format, including valid scopes, while accommodating work-in-progress designations and excluding non-critical labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->