### PR TITLE
refactor(packages/app): Refactor services to `use` service pattern

### DIFF
--- a/packages/app/client/lib/utils.ts
+++ b/packages/app/client/lib/utils.ts
@@ -1,18 +1,13 @@
 import { type Effect, type Layer, ManagedRuntime } from 'effect'
 import type { LoaderFunction } from 'react-router'
 
-// biome-ignore lint/nursery/useExplicitType: <explanation>
 export const makeRemixRuntime = <R, E>(layer: Layer.Layer<R, E, never>) => {
 	const runtime = ManagedRuntime.make(layer)
 
-	const loaderFunction: {
-		// biome-ignore lint/style/useShorthandFunctionType: <explanation>
-		<A, E>(
-			body: (...args: Parameters<LoaderFunction>) => Effect.Effect<A, E, R>,
-		): (...args: Parameters<LoaderFunction>) => Promise<A>
-	} =
+	const loaderFunction: <A, E>(
+		body: (...args: Parameters<LoaderFunction>) => Effect.Effect<A, E, R>,
+	) => (...args: Parameters<LoaderFunction>) => Promise<A> =
 		body =>
-		// biome-ignore lint/nursery/useExplicitType: <explanation>
 		(...args) =>
 			runtime.runPromise(body(...args))
 

--- a/packages/app/client/routes/resume/resume.tsx
+++ b/packages/app/client/routes/resume/resume.tsx
@@ -52,8 +52,8 @@ export const links: Route.LinksFunction = () => {
 export const loader = loaderFunction(
 	() =>
 		Effect.gen(function* () {
-			const { resume, meta } = yield* ResumeRepository.getResume()
-			return { resume, meta }
+			const { getResume } = yield* ResumeRepository
+			return yield* getResume()
 		}),
 	// still need to handle the error cases here!!
 )

--- a/packages/app/client/services/index.ts
+++ b/packages/app/client/services/index.ts
@@ -1,10 +1,10 @@
 import { Layer } from 'effect'
 
 import { makeRemixRuntime } from '#root/client/lib/utils.ts'
-import { OctokitService } from '#root/client/services/octokit.ts'
+import { Octokit } from '#root/client/services/octokit.ts'
 import { ResumeRepository } from '#root/client/services/resume-repository.ts'
 import { TodoRepo } from '#root/client/services/todos-repo.ts'
 
 export const { loaderFunction } = makeRemixRuntime(
-	Layer.mergeAll(TodoRepo.Live, OctokitService.Live, ResumeRepository.Live),
+	Layer.mergeAll(TodoRepo.Live, Octokit.Default, ResumeRepository.Live),
 )

--- a/packages/app/client/services/index.ts
+++ b/packages/app/client/services/index.ts
@@ -6,5 +6,5 @@ import { ResumeRepository } from '#root/client/services/resume-repository.ts'
 import { TodoRepo } from '#root/client/services/todos-repo.ts'
 
 export const { loaderFunction } = makeRemixRuntime(
-	Layer.mergeAll(TodoRepo.Live, Octokit.Default, ResumeRepository.Live),
+	Layer.mergeAll(TodoRepo.Live, Octokit.Default, ResumeRepository.Default),
 )

--- a/packages/app/client/services/resume-repository.ts
+++ b/packages/app/client/services/resume-repository.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Layer, Option, Schema } from 'effect'
+import { Data, Effect, Option, Schema } from 'effect'
 import type { ParseError } from 'effect/ParseResult'
 
 import { Resume } from '@suddenly-giovanni/schema-resume'
@@ -244,10 +244,13 @@ function getResume(
 
 const makeResumeRepository = Effect.sync(() => ({ getResume }))
 
-export class ResumeRepository extends Effect.Tag('@services/ResumeRepository')<
-	ResumeRepository,
-	Effect.Effect.Success<typeof makeResumeRepository>
->() {
-	// biome-ignore lint/style/useNamingConvention: <explanation>
-	static Live = Layer.effect(this, makeResumeRepository)
-}
+export class ResumeRepository extends Effect.Service<ResumeRepository>()(
+	'app/services/ResumeRepository',
+	{
+		effect: Effect.gen(function* () {
+			const { getResume } = yield* makeResumeRepository
+
+			return { getResume } as const
+		}),
+	},
+) {}

--- a/packages/app/client/services/resume-repository.ts
+++ b/packages/app/client/services/resume-repository.ts
@@ -66,128 +66,6 @@ class DecodingError extends Data.TaggedError('DecodingError')<{
 	readonly encoding?: string
 }> {}
 
-/**
- * Retrieves and decodes a file from a GitHub repository.
- *
- * This function uses the Octokit GitHub API client to fetch the content of a specified file. It verifies that the response represents a file matching the expected path and decodes its Base64-encoded content into a UTF-8 string. Additionally, it extracts metadata such as the canonical URL and the last modified date from the response headers, if available.
- *
- * @param owner - The owner of the repository.
- * @param repo - The name of the repository.
- * @param path - The file path within the repository.
- * @param ref - An optional branch, tag, or commit SHA to retrieve the file from.
- *
- * @returns An object containing:
- *   - decodedContent: The file content decoded to a UTF-8 string.
- *   - canonical: The canonical URL of the file, if available.
- *   - lastModified: The last modified timestamp from the API response headers, if available.
- *
- * @remarks
- * The function may fail with a RequestError if the API request fails, an InvalidDataError if the response data
- * does not match the expected format, or a DecodingError if decoding the file content fails.
- */
-function getResumeFile({
-	owner,
-	repo,
-	path,
-	ref,
-}: {
-	/**
-	 * The owner of a resource.
-	 */
-	readonly owner: string
-
-	/**
-	 * Repository variable.
-	 */
-	readonly repo: string
-
-	/**
-	 * The path variable represents a string that stores a file path.
-	 */
-	readonly path: string
-
-	/**
-	 * the branch, tag, or commit sha to get the file from
-	 */
-	readonly ref?: string
-}) {
-	return Effect.gen(function* () {
-		const octokit = yield* Octokit
-
-		const octokitResponse = yield* octokit.use((client, signal) =>
-			client.rest.repos.getContent({
-				owner: owner,
-				repo: repo,
-				path: path,
-				...(ref ? { ref } : {}),
-				request: {
-					signal,
-				},
-			}),
-		)
-
-		// yield* Console.debug(octokitResponse)
-
-		const {
-			content,
-			encoding,
-			_links: { html: maybeCanonical },
-		} = yield* Effect.succeed(octokitResponse).pipe(
-			Effect.flatMap(({ data }) => {
-				/**
-				 * the api returns data in different formats depending on the parameters passed to the getContent request.
-				 * We have asked for a single file, not a directory, therefore we expect a single object to be returned.
-				 * We need to type guard the data to ensure it is the correct type.
-				 *
-				 * If the data differs from our expectations, we should throw an error.
-				 * This could be due to the file not existing, or the path being incorrect.
-				 * Not recoverable at runtime, strategy:
-				 * - fail
-				 * - notify
-				 */
-				return typeof data === 'object' && !Array.isArray(data)
-					? Effect.succeed(data)
-					: Effect.fail(
-							new InvalidDataError({ message: `Expected an object, but got: ${typeof data}` }),
-						)
-			}),
-
-			Effect.flatMap(data => {
-				/**
-				 * The data returned from the getContent request not being an object or being an array,
-				 * or not having the correct type, name, or path. These are issues with the data returned
-				 * from the API and the program should fail if it cannot process the data.
-				 * Strategy:
-				 * - fail
-				 * - notify
-				 */
-				return data.type === 'file' && data.path === path
-					? Effect.succeed(data)
-					: Effect.fail(
-							new InvalidDataError({
-								message: `Expected a file matching the correct path and name; got "${data.type}"`,
-							}),
-						)
-			}),
-		)
-
-		const decodedContent = yield* Effect.try({
-			try: (): string => Buffer.from(content, 'base64').toString('utf8'),
-			catch: (_error): DecodingError =>
-				new DecodingError({
-					message: 'failed to parse data content',
-					encoding: encoding,
-				}),
-		})
-
-		return {
-			decodedContent,
-			canonical: Option.fromNullable(maybeCanonical),
-			lastModified: Option.fromNullable(octokitResponse.headers['last-modified']),
-		}
-	}).pipe(Effect.withLogSpan('getResumeFile'))
-}
-
 class Package extends Schema.Class<Package>('Package')({
 	version: Schema.TemplateLiteral(Schema.Number, '.', Schema.Number, '.', Schema.Number),
 }) {
@@ -197,58 +75,180 @@ class Package extends Schema.Class<Package>('Package')({
 const decodeResume = Schema.decode(parseYml(Resume))
 const decodePackageJson = Schema.decode(Schema.parseJson(Package))
 
-/**
- * Retrieves and decodes resume data and associated metadata from a GitHub repository.
- *
- * This function concurrently fetches the resume YAML file and the Deno package JSON file from a fixed repository.
- * It decodes the resume content and package information, then constructs metadata from available last modified dates,
- * canonical URLs, and version details from the package file. The function returns an effect that resolves to an object
- * containing both the decoded resume and the constructed metadata. The default Git reference used is "main".
- *
- * @param ref - The Git reference (branch, tag, etc.) to use when fetching the files. Defaults to "main".
- * @returns An effect that resolves to an object with the decoded resume and its metadata.
- */
-function getResume(
-	ref = 'main',
-): Effect.Effect<
-	{ meta: typeof Meta.Type; resume: typeof Resume.Type },
-	DecodingError | InvalidDataError | ParseError | OctokitError,
-	Octokit
-> {
-	const repo = 'resume'
-	const owner = 'suddenlyGiovanni'
-
-	return Effect.gen(function* () {
-		const [resumeFile, denoFile] = yield* Effect.all(
-			[
-				getResumeFile({ owner, path: 'packages/resume/src/resume.yml', ref, repo }),
-				getResumeFile({ owner, path: 'packages/resume/deno.json', ref, repo }),
-			],
-			{ concurrency: 2 },
-		)
-
-		const resume: typeof Resume.Type = yield* decodeResume(resumeFile.decodedContent)
-		const denoJson: typeof Package.Type = yield* decodePackageJson(denoFile.decodedContent)
-
-		const meta: typeof Meta.Type = yield* Meta.decode({
-			...(Option.isSome(resumeFile.lastModified)
-				? { lastModified: resumeFile.lastModified.value }
-				: {}),
-			...(Option.isSome(resumeFile.canonical) ? { canonical: resumeFile.canonical.value } : {}),
-			version: denoJson.version,
-		})
-
-		return { meta, resume }
-	}).pipe(Effect.withLogSpan('getResume'))
-}
-
-const makeResumeRepository = Effect.sync(() => ({ getResume }))
-
 export class ResumeRepository extends Effect.Service<ResumeRepository>()(
 	'app/services/ResumeRepository',
 	{
 		effect: Effect.gen(function* () {
-			const { getResume } = yield* makeResumeRepository
+			/**
+			 * Retrieves and decodes a file from a GitHub repository.
+			 *
+			 * This function uses the Octokit GitHub API client to fetch the content of a specified file. It verifies that the response represents a file matching the expected path and decodes its Base64-encoded content into a UTF-8 string. Additionally, it extracts metadata such as the canonical URL and the last modified date from the response headers, if available.
+			 *
+			 * @param owner - The owner of the repository.
+			 * @param repo - The name of the repository.
+			 * @param path - The file path within the repository.
+			 * @param ref - An optional branch, tag, or commit SHA to retrieve the file from.
+			 *
+			 * @returns An object containing:
+			 *   - decodedContent: The file content decoded to a UTF-8 string.
+			 *   - canonical: The canonical URL of the file, if available.
+			 *   - lastModified: The last modified timestamp from the API response headers, if available.
+			 *
+			 * @remarks
+			 * The function may fail with a RequestError if the API request fails, an InvalidDataError if the response data
+			 * does not match the expected format, or a DecodingError if decoding the file content fails.
+			 */
+			function getResumeFile({
+				owner,
+				repo,
+				path,
+				ref,
+			}: {
+				/**
+				 * The owner of a resource.
+				 */
+				readonly owner: string
+
+				/**
+				 * Repository variable.
+				 */
+				readonly repo: string
+
+				/**
+				 * The path variable represents a string that stores a file path.
+				 */
+				readonly path: string
+
+				/**
+				 * the branch, tag, or commit sha to get the file from
+				 */
+				readonly ref?: string
+			}) {
+				return Effect.gen(function* () {
+					const octokit = yield* Octokit
+
+					const octokitResponse = yield* octokit.use((client, signal) =>
+						client.rest.repos.getContent({
+							owner: owner,
+							repo: repo,
+							path: path,
+							...(ref ? { ref } : {}),
+							request: {
+								signal,
+							},
+						}),
+					)
+
+					// yield* Console.debug(octokitResponse)
+
+					const {
+						content,
+						encoding,
+						_links: { html: maybeCanonical },
+					} = yield* Effect.succeed(octokitResponse).pipe(
+						Effect.flatMap(({ data }) => {
+							/**
+							 * the api returns data in different formats depending on the parameters passed to the getContent request.
+							 * We have asked for a single file, not a directory, therefore we expect a single object to be returned.
+							 * We need to type guard the data to ensure it is the correct type.
+							 *
+							 * If the data differs from our expectations, we should throw an error.
+							 * This could be due to the file not existing, or the path being incorrect.
+							 * Not recoverable at runtime, strategy:
+							 * - fail
+							 * - notify
+							 */
+							return typeof data === 'object' && !Array.isArray(data)
+								? Effect.succeed(data)
+								: Effect.fail(
+										new InvalidDataError({
+											message: `Expected an object, but got: ${typeof data}`,
+										}),
+									)
+						}),
+
+						Effect.flatMap(data => {
+							/**
+							 * The data returned from the getContent request not being an object or being an array,
+							 * or not having the correct type, name, or path. These are issues with the data returned
+							 * from the API and the program should fail if it cannot process the data.
+							 * Strategy:
+							 * - fail
+							 * - notify
+							 */
+							return data.type === 'file' && data.path === path
+								? Effect.succeed(data)
+								: Effect.fail(
+										new InvalidDataError({
+											message: `Expected a file matching the correct path and name; got "${data.type}"`,
+										}),
+									)
+						}),
+					)
+
+					const decodedContent = yield* Effect.try({
+						try: (): string => Buffer.from(content, 'base64').toString('utf8'),
+						catch: (_error): DecodingError =>
+							new DecodingError({
+								message: 'failed to parse data content',
+								encoding: encoding,
+							}),
+					})
+
+					return {
+						decodedContent,
+						canonical: Option.fromNullable(maybeCanonical),
+						lastModified: Option.fromNullable(octokitResponse.headers['last-modified']),
+					}
+				}).pipe(Effect.withLogSpan('getResumeFile'))
+			}
+
+			/**
+			 * Retrieves and decodes resume data and associated metadata from a GitHub repository.
+			 *
+			 * This function concurrently fetches the resume YAML file and the Deno package JSON file from a fixed repository.
+			 * It decodes the resume content and package information, then constructs metadata from available last modified dates,
+			 * canonical URLs, and version details from the package file. The function returns an effect that resolves to an object
+			 * containing both the decoded resume and the constructed metadata. The default Git reference used is "main".
+			 *
+			 * @param ref - The Git reference (branch, tag, etc.) to use when fetching the files. Defaults to "main".
+			 * @returns An effect that resolves to an object with the decoded resume and its metadata.
+			 */
+			function getResume(
+				ref = 'main',
+			): Effect.Effect<
+				{ meta: typeof Meta.Type; resume: typeof Resume.Type },
+				DecodingError | InvalidDataError | ParseError | OctokitError,
+				Octokit
+			> {
+				const repo = 'resume'
+				const owner = 'suddenlyGiovanni'
+
+				return Effect.gen(function* () {
+					const [resumeFile, denoFile] = yield* Effect.all(
+						[
+							getResumeFile({ owner, path: 'packages/resume/src/resume.yml', ref, repo }),
+							getResumeFile({ owner, path: 'packages/resume/deno.json', ref, repo }),
+						],
+						{ concurrency: 2 },
+					)
+
+					const resume: typeof Resume.Type = yield* decodeResume(resumeFile.decodedContent)
+					const denoJson: typeof Package.Type = yield* decodePackageJson(denoFile.decodedContent)
+
+					const meta: typeof Meta.Type = yield* Meta.decode({
+						...(Option.isSome(resumeFile.lastModified)
+							? { lastModified: resumeFile.lastModified.value }
+							: {}),
+						...(Option.isSome(resumeFile.canonical)
+							? { canonical: resumeFile.canonical.value }
+							: {}),
+						version: denoJson.version,
+					})
+
+					return { meta, resume }
+				}).pipe(Effect.withLogSpan('getResume'))
+			}
 
 			return { getResume } as const
 		}),

--- a/packages/app/client/services/resume-repository.ts
+++ b/packages/app/client/services/resume-repository.ts
@@ -98,110 +98,111 @@ export class ResumeRepository extends Effect.Service<ResumeRepository>()(
 			 * The function may fail with a RequestError if the API request fails, an InvalidDataError if the response data
 			 * does not match the expected format, or a DecodingError if decoding the file content fails.
 			 */
-			function getResumeFile({
-				owner,
-				repo,
-				path,
-				ref,
-			}: {
-				/**
-				 * The owner of a resource.
-				 */
-				readonly owner: string
+			const getResumeFile = Effect.fn('ResumeRepository.getResumeFile')(
+				({
+					owner,
+					repo,
+					path,
+					ref,
+				}: {
+					/**
+					 * The owner of a resource.
+					 */
+					readonly owner: string
 
-				/**
-				 * Repository variable.
-				 */
-				readonly repo: string
+					/**
+					 * Repository variable.
+					 */
+					readonly repo: string
 
-				/**
-				 * The path variable represents a string that stores a file path.
-				 */
-				readonly path: string
+					/**
+					 * The path variable represents a string that stores a file path.
+					 */
+					readonly path: string
 
-				/**
-				 * the branch, tag, or commit sha to get the file from
-				 */
-				readonly ref?: string
-			}) {
-				return Effect.gen(function* () {
-					const octokit = yield* Octokit
+					/**
+					 * the branch, tag, or commit sha to get the file from
+					 */
+					readonly ref?: string
+				}) =>
+					Effect.gen(function* () {
+						const octokit = yield* Octokit
 
-					const octokitResponse = yield* octokit.use((client, signal) =>
-						client.rest.repos.getContent({
-							owner: owner,
-							repo: repo,
-							path: path,
-							...(ref ? { ref } : {}),
-							request: {
-								signal,
-							},
-						}),
-					)
-
-					// yield* Console.debug(octokitResponse)
-
-					const {
-						content,
-						encoding,
-						_links: { html: maybeCanonical },
-					} = yield* Effect.succeed(octokitResponse).pipe(
-						Effect.flatMap(({ data }) => {
-							/**
-							 * the api returns data in different formats depending on the parameters passed to the getContent request.
-							 * We have asked for a single file, not a directory, therefore we expect a single object to be returned.
-							 * We need to type guard the data to ensure it is the correct type.
-							 *
-							 * If the data differs from our expectations, we should throw an error.
-							 * This could be due to the file not existing, or the path being incorrect.
-							 * Not recoverable at runtime, strategy:
-							 * - fail
-							 * - notify
-							 */
-							return typeof data === 'object' && !Array.isArray(data)
-								? Effect.succeed(data)
-								: Effect.fail(
-										new InvalidDataError({
-											message: `Expected an object, but got: ${typeof data}`,
-										}),
-									)
-						}),
-
-						Effect.flatMap(data => {
-							/**
-							 * The data returned from the getContent request not being an object or being an array,
-							 * or not having the correct type, name, or path. These are issues with the data returned
-							 * from the API and the program should fail if it cannot process the data.
-							 * Strategy:
-							 * - fail
-							 * - notify
-							 */
-							return data.type === 'file' && data.path === path
-								? Effect.succeed(data)
-								: Effect.fail(
-										new InvalidDataError({
-											message: `Expected a file matching the correct path and name; got "${data.type}"`,
-										}),
-									)
-						}),
-					)
-
-					const decodedContent = yield* Effect.try({
-						try: (): string => Buffer.from(content, 'base64').toString('utf8'),
-						catch: (_error): DecodingError =>
-							new DecodingError({
-								message: 'failed to parse data content',
-								encoding: encoding,
+						const octokitResponse = yield* octokit.use((client, signal) =>
+							client.rest.repos.getContent({
+								owner: owner,
+								repo: repo,
+								path: path,
+								...(ref ? { ref } : {}),
+								request: {
+									signal,
+								},
 							}),
-					})
+						)
 
-					return {
-						decodedContent,
-						canonical: Option.fromNullable(maybeCanonical),
-						lastModified: Option.fromNullable(octokitResponse.headers['last-modified']),
-					}
-				}).pipe(Effect.withLogSpan('getResumeFile'))
-			}
+						// yield* Console.debug(octokitResponse)
+
+						const {
+							content,
+							encoding,
+							_links: { html: maybeCanonical },
+						} = yield* Effect.succeed(octokitResponse).pipe(
+							Effect.flatMap(({ data }) => {
+								/**
+								 * the api returns data in different formats depending on the parameters passed to the getContent request.
+								 * We have asked for a single file, not a directory, therefore we expect a single object to be returned.
+								 * We need to type guard the data to ensure it is the correct type.
+								 *
+								 * If the data differs from our expectations, we should throw an error.
+								 * This could be due to the file not existing, or the path being incorrect.
+								 * Not recoverable at runtime, strategy:
+								 * - fail
+								 * - notify
+								 */
+								return typeof data === 'object' && !Array.isArray(data)
+									? Effect.succeed(data)
+									: Effect.fail(
+											new InvalidDataError({
+												message: `Expected an object, but got: ${typeof data}`,
+											}),
+										)
+							}),
+
+							Effect.flatMap(data => {
+								/**
+								 * The data returned from the getContent request not being an object or being an array,
+								 * or not having the correct type, name, or path. These are issues with the data returned
+								 * from the API and the program should fail if it cannot process the data.
+								 * Strategy:
+								 * - fail
+								 * - notify
+								 */
+								return data.type === 'file' && data.path === path
+									? Effect.succeed(data)
+									: Effect.fail(
+											new InvalidDataError({
+												message: `Expected a file matching the correct path and name; got "${data.type}"`,
+											}),
+										)
+							}),
+						)
+
+						const decodedContent = yield* Effect.try({
+							try: (): string => Buffer.from(content, 'base64').toString('utf8'),
+							catch: (_error): DecodingError =>
+								new DecodingError({
+									message: 'failed to parse data content',
+									encoding: encoding,
+								}),
+						})
+
+						return {
+							decodedContent,
+							canonical: Option.fromNullable(maybeCanonical),
+							lastModified: Option.fromNullable(octokitResponse.headers['last-modified']),
+						}
+					}),
+			)
 
 			/**
 			 * Retrieves and decodes resume data and associated metadata from a GitHub repository.
@@ -214,41 +215,46 @@ export class ResumeRepository extends Effect.Service<ResumeRepository>()(
 			 * @param ref - The Git reference (branch, tag, etc.) to use when fetching the files. Defaults to "main".
 			 * @returns An effect that resolves to an object with the decoded resume and its metadata.
 			 */
-			function getResume(
-				ref = 'main',
-			): Effect.Effect<
-				{ meta: typeof Meta.Type; resume: typeof Resume.Type },
-				DecodingError | InvalidDataError | ParseError | OctokitError,
-				Octokit
-			> {
-				const repo = 'resume'
-				const owner = 'suddenlyGiovanni'
+			const getResume = Effect.fn('ResumeRepository.getResume')(
+				(
+					ref = 'main',
+				): Effect.Effect<
+					{
+						meta: typeof Meta.Type
+						resume: typeof Resume.Type
+					},
+					DecodingError | InvalidDataError | ParseError | OctokitError,
+					Octokit
+				> => {
+					const repo = 'resume'
+					const owner = 'suddenlyGiovanni'
 
-				return Effect.gen(function* () {
-					const [resumeFile, denoFile] = yield* Effect.all(
-						[
-							getResumeFile({ owner, path: 'packages/resume/src/resume.yml', ref, repo }),
-							getResumeFile({ owner, path: 'packages/resume/deno.json', ref, repo }),
-						],
-						{ concurrency: 2 },
-					)
+					return Effect.gen(function* () {
+						const [resumeFile, denoFile] = yield* Effect.all(
+							[
+								getResumeFile({ owner, path: 'packages/resume/src/resume.yml', ref, repo }),
+								getResumeFile({ owner, path: 'packages/resume/deno.json', ref, repo }),
+							],
+							{ concurrency: 2 },
+						)
 
-					const resume: typeof Resume.Type = yield* decodeResume(resumeFile.decodedContent)
-					const denoJson: typeof Package.Type = yield* decodePackageJson(denoFile.decodedContent)
+						const resume: typeof Resume.Type = yield* decodeResume(resumeFile.decodedContent)
+						const denoJson: typeof Package.Type = yield* decodePackageJson(denoFile.decodedContent)
 
-					const meta: typeof Meta.Type = yield* Meta.decode({
-						...(Option.isSome(resumeFile.lastModified)
-							? { lastModified: resumeFile.lastModified.value }
-							: {}),
-						...(Option.isSome(resumeFile.canonical)
-							? { canonical: resumeFile.canonical.value }
-							: {}),
-						version: denoJson.version,
+						const meta: typeof Meta.Type = yield* Meta.decode({
+							...(Option.isSome(resumeFile.lastModified)
+								? { lastModified: resumeFile.lastModified.value }
+								: {}),
+							...(Option.isSome(resumeFile.canonical)
+								? { canonical: resumeFile.canonical.value }
+								: {}),
+							version: denoJson.version,
+						})
+
+						return { meta, resume } as const
 					})
-
-					return { meta, resume }
-				}).pipe(Effect.withLogSpan('getResume'))
-			}
+				},
+			)
 
 			return { getResume } as const
 		}),


### PR DESCRIPTION
### Summary

This pull request includes a series of refactorings aimed at improving the service layers' composability, readability, and maintainability. Key changes include:

- Refactored `getResumeFile` and `getResume` functions to utilize `Effect.fn` for better standardization and functional programming alignment.
- Reorganized `ResumeRepository` logic by encapsulating methods, aligning with new schema decoding patterns, and restructuring for modularity.
- Streamlined the `ResumeRepository` structure with `Effect.Service`, updating methods and loaders for consistency.
- Simplified and enhanced `Octokit` handling by introducing a refined structure, replacing `OctokitService`, and improving error handling.

These changes are intended to enhance the overall codebase clarity and facilitate easier maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced GitHub and resume data services with improved error handling and encapsulation.
  - Updated runtime setup to utilize new service classes for GitHub API and resume data.
- **Chores**
  - Simplified internal type annotations and removed redundant comments for cleaner code.

No changes to visible features or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->