### PR TITLE
ci(monorepo): remove unused environment input

### DIFF
--- a/.github/workflows/deploy-preview-cleanup.yml
+++ b/.github/workflows/deploy-preview-cleanup.yml
@@ -60,8 +60,7 @@ jobs:
 
       - name: 🗑️ Destroy PR app in Fly.io
         id: destroy_app
-        continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup ==
-        'true' }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup == 'true'}}
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_APP_REVIEW }}

--- a/.github/workflows/deploy-preview-cleanup.yml
+++ b/.github/workflows/deploy-preview-cleanup.yml
@@ -60,20 +60,31 @@ jobs:
 
       - name: 🗑️ Destroy PR app in Fly.io
         id: destroy_app
-        continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup == 'true' }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup ==
+        'true' }}
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_APP_REVIEW }}
           FLY_REGION: ams
           FLY_ORG: personal
         run: |
-          echo "Destroying Fly app: ${{ steps.vars.outputs.FLY_APP_NAME }}"
-          flyctl apps destroy ${{ steps.vars.outputs.FLY_APP_NAME }} -y || {
-            echo "::warning::Failed to destroy Fly app ${{ steps.vars.outputs.FLY_APP_NAME }}. It may not exist or there was an error."
-            if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ github.event.inputs.force_cleanup }}" != "true" ]]; then
+          set -euo pipefail
+          
+          APP="${{ steps.vars.outputs.FLY_APP_NAME }}"
+          echo "Destroying Fly app: ${APP}"
+
+          # capture output + exit code of destroy command
+          destroy_output=$(mktemp)
+          if flyctl apps destroy "${APP}" -y 2>&1 | tee "${destroy_output}"; then
+            echo "::notice::Fly app ${APP} destroyed."
+          else
+            if grep -qiE "not found|could not resolve" "${destroy_output}"; then
+              echo "::notice::Fly app ${APP} not found – skipping."
+            elif [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ github.event.inputs.force_cleanup }}" != "true" ]]; then
+              echo "::warning::Failed to destroy Fly app ${APP}."
               exit 1
             fi
-          } 
+          fi
 
       - name: 🗑 Delete deployment environment
         id: delete_environment

--- a/.github/workflows/deploy-preview-cleanup.yml
+++ b/.github/workflows/deploy-preview-cleanup.yml
@@ -55,17 +55,25 @@ jobs:
         with:
           pr_number: ${{ github.event.inputs.pr_number || github.event.number }}
 
+      - name: Install Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
       - name: 🗑️ Destroy PR app in Fly.io
         id: destroy_app
         continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup == 'true' }}
-        uses: superfly/fly-pr-review-apps@1.5.0
+        shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_APP_REVIEW }}
           FLY_REGION: ams
           FLY_ORG: personal
-        with:
-          config: ./packages/app/fly.review.yaml
-          name: ${{ steps.vars.outputs.FLY_APP_NAME }}
+        run: |
+          echo "Destroying Fly app: ${{ steps.vars.outputs.FLY_APP_NAME }}"
+          flyctl apps destroy ${{ steps.vars.outputs.FLY_APP_NAME }} -y || {
+            echo "::warning::Failed to destroy Fly app ${{ steps.vars.outputs.FLY_APP_NAME }}. It may not exist or there was an error."
+            if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ github.event.inputs.force_cleanup }}" != "true" ]]; then
+              exit 1
+            fi
+          } 
 
       - name: 🗑 Delete deployment environment
         id: delete_environment

--- a/.github/workflows/validate-secrets.yml
+++ b/.github/workflows/validate-secrets.yml
@@ -14,7 +14,6 @@ jobs:
   validate:
     name: Validate Required Secrets
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     steps:
       - name: ✅ Verify required secrets are set
         id: verify


### PR DESCRIPTION
The 'environment' input was removed from the validate-secrets workflow as it was unused and unnecessary. This change simplifies the
 workflow configuration without affecting functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved deployment cleanup with enhanced error handling and direct command-line usage.
  - Updated secret validation workflow by removing the environment property from the job configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->