### PR TITLE
chore(monorepo): refine PR-specific image cleanup logic

### DIFF
--- a/.github/workflows/deploy-preview-cleanup.yml
+++ b/.github/workflows/deploy-preview-cleanup.yml
@@ -102,6 +102,7 @@ jobs:
           PKG_NAME: ${{ steps.vars.outputs.PACKAGE_NAME_PREVIEW }}
           PR_NUMBER: ${{ steps.vars.outputs.PR_NUMBER }}
           OWNER: ${{ github.repository_owner }}
+        shell: bash
         run: |
           set -euo pipefail
 

--- a/.github/workflows/deploy-preview-cleanup.yml
+++ b/.github/workflows/deploy-preview-cleanup.yml
@@ -94,16 +94,47 @@ jobs:
           token: ${{ secrets.DELETE_DEPLOYMENT_PAT_TOKEN }}
           environment: fly-preview-${{ github.event.number || github.event.inputs.pr_number }}
 
-      - name: 🗑 Delete GHCR preview images for closed PR
+      - name: 🗑 Delete GHCR images for this PR only
         id: delete_images
         continue-on-error: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_cleanup == 'true' }}
-        uses: actions/delete-package-versions@v5
-        with:
-          owner: ${{ github.repository_owner }}
-          package-name: ${{ steps.vars.outputs.PACKAGE_NAME_PREVIEW }}
-          package-type: "container"
-          min-versions-to-keep: 0
-          token: ${{ secrets.DELETE_DEPLOYMENT_PAT_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.DELETE_DEPLOYMENT_PAT_TOKEN }}   # must have delete-packages scope
+          PKG_NAME: ${{ steps.vars.outputs.PACKAGE_NAME_PREVIEW }}
+          PR_NUMBER: ${{ steps.vars.outputs.PR_NUMBER }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          echo "Looking for versions of '${PKG_NAME}' whose tags belong to PR #${PR_NUMBER} …"
+
+          # collect version IDs whose tag list contains pr-<PR> or pr-<PR>-<sha>
+          mapfile -t VERSION_IDS < <(
+            gh api -H "Accept: application/vnd.github+json" \
+              "/orgs/${OWNER}/packages/container/${PKG_NAME}/versions?per_page=100" \
+              --paginate \
+              --jq ".[] |
+                    select(
+                      .metadata.container.tags[]? |
+                      test(\"^pr-${PR_NUMBER}(-[0-9a-f]+)?$\")
+                    ) |
+                    .id"
+          )
+
+          if [[ ${#VERSION_IDS[@]} -eq 0 ]]; then
+            echo "No container versions found for this PR – nothing to delete."
+            exit 0
+          fi
+
+          echo "Found ${#VERSION_IDS[@]} version(s) to delete:"
+          printf '  • %s\n' "${VERSION_IDS[@]}"
+
+          for id in "${VERSION_IDS[@]}"; do
+            echo "::group::Deleting version $id"
+            gh api -X DELETE "/orgs/${OWNER}/packages/container/${PKG_NAME}/versions/${id}"
+            echo "::endgroup::"
+          done
+
+          echo "::notice::Deleted ${#VERSION_IDS[@]} PR-specific image version(s)."
 
       - name: 📢 Post cleanup notification
         if: always()


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy-preview-cleanup.yml` file to enhance the process of cleaning up container images for pull requests. The main change involves replacing the use of a third-party GitHub Action with a custom script to delete specific container image versions associated with a PR.

### Workflow Enhancements:
* Replaced the `actions/delete-package-versions@v5` GitHub Action with a custom script using the `gh` CLI to delete container image versions associated with a specific PR. This allows for more granular control and ensures only PR-specific images are targeted for deletion.
* Added logging to display the container image versions identified for deletion and confirmation messages after deletion.
* Introduced environment variables (`GH_TOKEN`, `PKG_NAME`, `PR_NUMBER`, `OWNER`) to support the custom script.Updated the deploy-preview-cleanup workflow to target and delete only
 GHCR images specific to a given PR. Replaced the
 `delete-package-versions` action with a custom script leveraging the
  GitHub API for more precise cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the cleanup process for preview images by using a custom script, ensuring only images related to the current pull request are deleted during workflow runs. No user-facing features or functionality are affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->