### PR TITLE
chore(ci): group dependancies for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,7 +63,7 @@
 		},
 		{
 			groupName: "tailwindcss packages",
-			matchPackageNames: ["@tailwindcss/vite", "tailwindcss"],
+			matchPackageNames: ["@tailwindcss/vite", "tailwindcss", "tailwind-variants", "@tailwindcss/typography", "tailwindcss-animate", "tailwind-merge" ],
 		},
 	],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,69 +1,104 @@
 {
-	$schema: "https://docs.renovatebot.com/renovate-schema.json",
-	configMigration: true,
-	semanticCommits: "enabled",
-	semanticCommitType: "chore",
-	semanticCommitScope: "monorepo",
-	prConcurrentLimit: 5,
-	dockerfile: {
-		enabled: true,
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  configMigration: true,
+  semanticCommits: "enabled",
+  semanticCommitType: "chore",
+  semanticCommitScope: "monorepo",
+  prConcurrentLimit: 5,
+  dockerfile: {
+	enabled: true,
+  },
+  extends: [
+	"config:recommended",
+	":pinDevDependencies",
+	"group:monorepos",
+	"group:recommended",
+	"replacements:all",
+	"workarounds:all",
+	":followTag(typescript, rc)",
+	"schedule:earlyMondays",
+	"packages:eslint",
+  ],
+  npmrcMerge: true,
+  hostRules: [
+	{
+	  matchHost: "https://npm.pkg.github.com/",
+	  hostType: "npm",
+	  token: "{{ secrets.REPO_GITHUB_PACKAGES_TOKEN }}",
 	},
-	extends: [
-		"config:recommended",
-		":pinDevDependencies",
-		"group:monorepos",
-		"group:recommended",
-		"replacements:all",
-		"workarounds:all",
-		":followTag(typescript, rc)",
-		"schedule:earlyMondays",
-		"packages:eslint",
-	],
-	npmrcMerge: true,
-	hostRules: [
-		{
-			matchHost: "https://npm.pkg.github.com/",
-			hostType: "npm",
-			token: "{{ secrets.REPO_GITHUB_PACKAGES_TOKEN }}",
-		},
-	],
-	labels: ["dependencies"],
-	packageRules: [
-		{
-			matchFileNames: ["packages/app/**"],
-			semanticCommitScope: "packages/app",
-		},
-		{
-			matchFileNames: ["packages/open-graph-protocol/**"],
-			semanticCommitScope: "packages/open-graph-protocol",
-		},
-		{
-			matchFileNames: ["packages/ui/**"],
-			semanticCommitScope: "packages/ui",
-		},
-		{
-			matchFileNames: ["tools/eslint-config/**"],
-			semanticCommitScope: "tools/eslint-config",
-		},
-		{
-			matchFileNames: ["tools/tailwind/**"],
-			semanticCommitScope: "tools/tailwind",
-		},
-		{
-			matchFileNames: ["tools/typescript/**"],
-			semanticCommitScope: "tools/typescript",
-		},
-		{
-			groupName: "effect packages",
-			matchPackageNames: ["/^effect$/", "/^@effect//"],
-		},
-		{
-			groupName: "eslint updates",
-			matchPackageNames: ["eslint", "/^eslint-/", "/^@.*eslint/"],
-		},
-		{
-			groupName: "tailwindcss packages",
-			matchPackageNames: ["@tailwindcss/vite", "tailwindcss", "tailwind-variants", "@tailwindcss/typography", "tailwindcss-animate", "tailwind-merge" ],
-		},
-	],
+  ],
+  labels: [
+	"dependencies"
+  ],
+  packageRules: [
+	{
+	  matchFileNames: [
+		"packages/app/**"
+	  ],
+	  semanticCommitScope: "packages/app",
+	},
+	{
+	  matchFileNames: [
+		"packages/open-graph-protocol/**"
+	  ],
+	  semanticCommitScope: "packages/open-graph-protocol",
+	},
+	{
+	  matchFileNames: [
+		"packages/ui/**"
+	  ],
+	  semanticCommitScope: "packages/ui",
+	},
+	{
+	  matchFileNames: [
+		"tools/eslint-config/**"
+	  ],
+	  semanticCommitScope: "tools/eslint-config",
+	},
+	{
+	  matchFileNames: [
+		"tools/tailwind/**"
+	  ],
+	  semanticCommitScope: "tools/tailwind",
+	},
+	{
+	  matchFileNames: [
+		"tools/typescript/**"
+	  ],
+	  semanticCommitScope: "tools/typescript",
+	},
+	{
+	  groupName: "effect packages",
+	  matchPackageNames: [
+		"/^effect$/",
+		"/^@effect//"
+	  ],
+	},
+	{
+	  groupName: "eslint updates",
+	  matchPackageNames: [
+		"@types/eslint",
+		"babel-eslint",
+		"@babel/eslint-parser",
+		"@eslint/**",
+		"@eslint-community/**",
+		"@stylistic/eslint-plugin**",
+		"@types/eslint__**",
+		"@typescript-eslint/**",
+		"typescript-eslint",
+		"eslint**"
+	  ]
+	},
+	{
+	  groupName: "tailwindcss packages",
+	  matchPackageNames: [
+		"@tailwindcss/vite",
+		"tailwindcss",
+		"tailwind-variants",
+		"@tailwindcss/typography",
+		"tailwindcss-animate",
+		"tailwind-merge"
+	  ],
+	},
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,7 @@
 	":followTag(typescript, rc)",
 	"schedule:earlyMondays",
 	"packages:eslint",
+	"packages:react"
   ],
   npmrcMerge: true,
   hostRules: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,8 @@
 	":followTag(typescript, rc)",
 	"schedule:earlyMondays",
 	"packages:eslint",
-	"packages:react"
+	"packages:react",
+	"packages:vite"
   ],
   npmrcMerge: true,
   hostRules: [


### PR DESCRIPTION
This pull request updates the `.github/renovate.json5` configuration file to improve dependency management and enhance readability. Key changes include adding new package groups, refining existing group definitions, and reformatting the file for better clarity.

### Dependency Management Improvements:

* Added new package groups for `react` and `vite` to the `extends` section, enabling Renovate to manage these dependencies more effectively.
* Expanded the `eslint updates` group to include additional ESLint-related packages, such as `@eslint/**`, `@eslint-community/**`, and `@typescript-eslint/**`, for more comprehensive dependency grouping.
* Enhanced the `tailwindcss packages` group by adding packages like `tailwind-variants`, `@tailwindcss/typography`, and `tailwindcss-animate`, ensuring better coverage of Tailwind-related dependencies.

### File Formatting Enhancements:

* Reformatted `labels`, `matchFileNames`, and `matchPackageNames` arrays to use multiline formatting, improving readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated and expanded Renovate configuration for improved package grouping, scheduling, and labeling.
  - Enhanced clarity and readability of configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->