### PR TITLE
chore(tools/typescript): Upgrade TypeScript configuration to Node.js v24 tsconfig

### DIFF
--- a/packages/app/src/server/tsconfig.node.json
+++ b/packages/app/src/server/tsconfig.node.json
@@ -20,6 +20,6 @@
 		"target": "es2024",
 		"types": ["node", "vite/client", "vitest/config", "vitest/importMeta"]
 	},
-	"extends": ["../../tsconfig.json", "@repo/typescript-config/library.json"],
+	"extends": ["../../tsconfig.json", "@repo/typescript-config/node.json"],
 	"include": ["**/*.ts", "../../react-router.config.ts", "../../vite.config.ts", "../types/**/*.ts"]
 }

--- a/packages/open-graph-protocol/tsconfig.json
+++ b/packages/open-graph-protocol/tsconfig.json
@@ -6,6 +6,6 @@
 		"useDefineForClassFields": true
 	},
 	"exclude": ["node_modules", "./~"],
-	"extends": "@repo/typescript-config/library.json",
+	"extends": "@repo/typescript-config/node.json",
 	"include": ["./src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,9 @@ catalogs:
       version: 3.1.3
 
 overrides:
+  '@types/react': ^19.1.2
   react: ~19.1.0
   react-dom: ~19.1.0
-  '@types/react': ^19.1.2
 
 importers:
 
@@ -403,9 +403,9 @@ importers:
       '@tsconfig/node-ts':
         specifier: 23.6.1
         version: 23.6.1
-      '@tsconfig/node23':
-        specifier: 23.0.1
-        version: 23.0.1
+      '@tsconfig/node24':
+        specifier: 24.0.0
+        version: 24.0.0
       '@tsconfig/strictest':
         specifier: 2.0.5
         version: 2.0.5
@@ -3008,8 +3008,8 @@ packages:
   '@tsconfig/node-ts@23.6.1':
     resolution: {integrity: sha512-1E5cUp+S65pLKKI9VrGMQPWDHxOEq3dAGM2onG3fLeSRwWbylYFwhIjnzJikjSN7w2nCgwxmv8ifvUKDFkK38Q==}
 
-  '@tsconfig/node23@23.0.1':
-    resolution: {integrity: sha512-oJ0Y42TmsBLuLAfEbPTS5JXSbJJEEU4bULROS6zsL54Gdlw5aOy27rpsquotMKGf2auP6rkbfYsjl43WdGrNcg==}
+  '@tsconfig/node24@24.0.0':
+    resolution: {integrity: sha512-3/6Cr4dELEAucgPIr6ufY7yBYMi4ttZFOewABADNZ+bm4DUZl4dup2VBcBeP1ejj3QblrWVWux/1XcRv/ZVikA==}
 
   '@tsconfig/strictest@2.0.5':
     resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
@@ -9311,7 +9311,7 @@ snapshots:
 
   '@tsconfig/node-ts@23.6.1': {}
 
-  '@tsconfig/node23@23.0.1': {}
+  '@tsconfig/node24@24.0.0': {}
 
   '@tsconfig/strictest@2.0.5': {}
 

--- a/tools/typescript/library.json
+++ b/tools/typescript/library.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"display": "Library",
-	"extends": ["./base.json", "@tsconfig/node23/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"]
+	"extends": ["./base.json", "@tsconfig/node24/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"]
 }

--- a/tools/typescript/node.json
+++ b/tools/typescript/node.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-	"display": "Library",
+	"display": "Node_24",
 	"extends": ["./base.json", "@tsconfig/node24/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"]
 }

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"dependencies": {
 		"@tsconfig/node-ts": "23.6.1",
-		"@tsconfig/node23": "23.0.1",
+		"@tsconfig/node24": "24.0.0",
 		"@tsconfig/strictest": "2.0.5",
 		"@tsconfig/vite-react": "3.4.0"
 	},

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -8,7 +8,7 @@
 	},
 	"exports": {
 		"./base.json": "./base.json",
-		"./library.json": "./library.json",
+		"./node.json": "./node.json",
 		"./react-library.json": "./react-library.json",
 		"./remix.json": "./remix.json"
 	},


### PR DESCRIPTION
**Chores**
  - Updated TypeScript configuration to use Node.js 24 settings across relevant packages.
  - Adjusted configuration references to ensure consistency with the new Node.js version.
  - Updated display names in configuration files for improved clarity.