### PR TITLE
chore(monorepo): Update pnpm to v10.12 and tweaked workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"packageManager": {
 			"name": "pnpm",
 			"onFail": "error",
-			"version": "10.10.0"
+			"version": "10.12.1"
 		},
 		"runtime": {
 			"name": "node",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,11 @@ onlyBuiltDependencies:
   - esbuild
   - msw
 autoInstallPeers: true
+catalogMode: prefer
 dedupePeerDependents: true
-strictPeerDependencies: false
+enableGlobalVirtualStore: true
 resolvePeersFromWorkspaceRoot: true
+strictPeerDependencies: false
 catalogs:
   lib:
     "@effect/platform": 0.84.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ onlyBuiltDependencies:
 autoInstallPeers: true
 catalogMode: prefer
 dedupePeerDependents: true
-enableGlobalVirtualStore: true
 resolvePeersFromWorkspaceRoot: true
 strictPeerDependencies: false
 catalogs:


### PR DESCRIPTION
Updated pnpm to version 10.12.1 and adjusted workspace settings to include `catalogMode`, enabled `enableGlobalVirtualStore`, and improved configuration clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the required version of the package manager.
  - Added new workspace configuration options and reorganized existing settings for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->